### PR TITLE
small renderMacro and rollAttackMacro improvements

### DIFF
--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -485,9 +485,15 @@ async function rollAttackMacro(w: string, a: string) {
 		}
 		// Reduce damage values to only this tier
 		damage = duplicate(wData.damage);
+		let typeMissing = false;
 		damage.forEach(d => {
 			d.val = d.val[tier];
+			if (d.type === '' && d.val != '' && d.val != 0) typeMissing = true;
 		});
+		// Warn about missing damage type if the value is non-zero
+		if (typeMissing) {
+			ui.notifications.warn(`Warning: ${item.name} has a damage value without type!`);
+		}
 		tags = wData.tags;
 		effect = wData.effect;
   }
@@ -511,6 +517,7 @@ async function rollAttackMacro(w: string, a: string) {
   // Iterate through damage types, rolling each
   let damage_results = [];
   damage.forEach(async x => {
+    if (x.type === '' || x.val === '' || x.val == 0) return Promise.resolve(); // Skip undefined and zero damage
     const droll = new Roll(x.val.toString()).roll();
     const tt = await droll.getTooltip();
     damage_results.push({

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -345,7 +345,8 @@ async function renderMacro(actor: Actor, template: string, templateData: any) {
 	const html = await renderTemplate(template, templateData)
 	let chat_data = {
 		user: game.user,
-		type: CONST.CHAT_MESSAGE_TYPES.IC,
+		type: CONST.CHAT_MESSAGE_TYPES.ROLL,
+		roll: templateData.roll || templateData.attack,
 		speaker: {
 			actor: actor
 		},

--- a/src/templates/chat/attack-card.html
+++ b/src/templates/chat/attack-card.html
@@ -18,6 +18,7 @@
       </div>
     </div>
   </div>
+  {{#if damages}}
   <div class="card clipped">
     <div class="lancer-stat-header clipped-top">// DAMAGE //</div>
     {{#each damages as |damage key|}}
@@ -35,6 +36,7 @@
       </div>
     {{/each}}
   </div>
+  {{/if}}
   {{#if effect}}
   <div class="card clipped">
     <div class="lancer-stat-header clipped-top">// EFFECT //</div>


### PR DESCRIPTION
Commit https://github.com/Eranziel/foundryvtt-lancer/commit/09ff99cb85c4a57f51016e68a78cda66aa946d81 fixes Eranziel/foundryvtt-lancer#59 
Commit https://github.com/Eranziel/foundryvtt-lancer/commit/0a737595492c9504ac79dccdda3fe3209699d57e adds
- a warning notification about (non-zero) damage values with no type selected.
- checks for invalid damage values before trying to roll them.
- a conditional in the attack-card template that makes attacks with no damage a bit cleaner (e.g. Scout Marker Rifle).