### PR TITLE
Fixed NPC inability to remove templates

### DIFF
--- a/src/module/actor/npc-sheet.ts
+++ b/src/module/actor/npc-sheet.ts
@@ -11,6 +11,7 @@ import {
   LancerNPCClass,
   LancerNPCFeature,
   LancerItemData,
+  LancerNPCTemplate,
 } from "../item/lancer-item";
 import { LancerActor } from "./lancer-actor";
 import { LANCER } from "../config";
@@ -83,7 +84,7 @@ export class LancerNPCSheet extends ActorSheet {
     let npc_item_data = (data.items as unknown) as LancerItemData[];
     let sorted = new ItemDataManifest().add_items(npc_item_data.values());
 
-    data.npc_templates = sorted.npc_templates.map(x => x.data); // Why does this work. Like someone fixed exactly one, lol???
+    data.npc_templates = (sorted.npc_templates as unknown) as LancerNPCTemplate[]; // Why does this work. Like someone fixed exactly one, lol???
     data.npc_features = (sorted.npc_features as unknown) as LancerNPCFeature[];
     data.npc_class = (sorted.npc_classes[0] as unknown) as LancerNPCClass;
     //TODO Templates, Classes and Features

--- a/src/module/interfaces.d.ts
+++ b/src/module/interfaces.d.ts
@@ -223,7 +223,7 @@ declare interface LancerNPCSheetData extends ActorSheetData {
   actor: LancerNPCActorData;
   data: LancerNPCData;
   npc_class: LancerNPCClass;
-  npc_templates: LancerNPCTemplateData[];
+  npc_templates: LancerNPCTemplate[];
   npc_features: LancerNPCFeature[];
 }
 


### PR DESCRIPTION
Closes #97 

Apparently somewhere along the line the NPC data was storing only LancerNPCTemplateData, instead of the item. Moving it up a level to LancerNPCTemplate makes it consistent with features and makes it easier to access the item ID, so it can be removed by the trash can on the sheet.