### PR TITLE
Reworked overkill tag

### DIFF
--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -381,9 +381,19 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
       let d_ind = d_formula.indexOf("d");
       let p_ind = d_formula.indexOf("+");
       if (d_ind >= 0) {
-        if (p_ind > d_ind)
-          d_formula = d_formula.substring(0, p_ind) + "r1" + d_formula.substring(p_ind);
-        else d_formula += "r1";
+        let d_count = "1";
+        let d_expr: RegExp = /\d+(?=d)/
+        if (d_ind != 0){
+          let match = d_expr.exec(d_formula);
+          //console.log(`${lp} Formula ${d_expr} matched ${match} in ${d_formula}`);
+          if (match != null) {
+            d_count = match[0];
+          }
+        }
+        if (p_ind > d_ind) {
+          d_formula = d_formula.substring(0, p_ind) + "x1kh" + d_count + d_formula.substring(p_ind);
+        }
+        else d_formula += ("x1kh" + d_count);
       }
     }
     let droll: Roll | null;
@@ -400,12 +410,13 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
       droll.parts.forEach(p => {
         if (p.rolls && Array.isArray(p.rolls)) {
           p.rolls.forEach((r: any) => {
-            if (r.roll && r.roll === 1 && r.rerolled) {
+            if (r.exploded) {
               overkill_heat += 1;
             }
           });
         }
       });
+      //console.log(`${lp} Overkill heat: ${overkill_heat}`);
     }
     if (droll && tt) {
       damage_results.push({

--- a/src/templates/chat/attack-card.html
+++ b/src/templates/chat/attack-card.html
@@ -38,9 +38,9 @@
     {{#if overkill_heat}}
       <div class="lancer-dice-total flexrow" style="">
         <span style="text-align: left; margin-left: 5px;">OVERKILL!</span>
-        {{!-- <span class="dice-total lancer-dice-total major">{{ overkill_heat }}</span> --}}
+        <span class="dice-total lancer-dice-total major">{{ overkill_heat }}</span>
         <i class="cci cci-heat i--m damage--heat"> </i>
-        <button class="overkill-reroll"><i class="fas fa-redo"></i> +d6</button>
+        {{!-- <button class="overkill-reroll"><i class="fas fa-redo"></i> +d6</button>  --}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
Overkill tag now uses a combination of exploding dice and keep highest to achieve repeated rerolls. Overkill reroll button was removed, but exploded dice gives an accurate count of heat in the attack card.