### PR TITLE
Add critical rolls during attacks

### DIFF
--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -414,15 +414,16 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
     try {
       droll = new Roll(x.val.toString());
       
-      for (var die in droll.dice) {
+      for (let die of droll.dice) {
+        if(!die instanceof DiceTerm) continue;
         // set an original die count
         var die_count = die.number;
         // double the number of dice rolled on critical
-        if(attack_roll.total >= 20) droll.dice[die].alter(2, 0);
+        if(attack_roll.total >= 20) die.number *= 2;
         // add die explosion on 1 and keep the highest of the original number of die
-        if(data.overkill) droll.dice[die].modifiers.push("x1");
+        if(data.overkill) die.modifiers.push("x1");
         // for both sections above, we want to keep the highest of the die count
-        if(attack_roll.total >= 20 || data.overkill) droll.dice[die].modifiers.push(`kh${die_count}`);
+        if(attack_roll.total >= 20 || data.overkill) die.modifiers.push(`kh${die_count}`);
       }
       
       droll = droll.roll();

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -422,7 +422,7 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
         // add die explosion on 1 and keep the highest of the original number of die
         if(data.overkill) droll.dice[die].modifiers.push("x1");
         // for both sections above, we want to keep the highest of the die count
-        droll.dice[die].modifiers.push(`kh${die_count}`);
+        if(attack_roll.total >= 20 || data.overkill) droll.dice[die].modifiers.push(`kh${die_count}`);
       }
       
       droll = droll.roll();

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -408,19 +408,20 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
   let overkill_heat: number = 0;
   for (const x of data.damage) {
     if (x.val === "" || x.val == 0) continue; // Skip undefined and zero damage
-    let d_roll = new Roll(x.val.toString());
-    
-    for (var die in d_roll.dice) {
-      // double the number of dice rolled on critical
-      if(attack_roll.total >= 20) d_roll.dice[die].alter(2, 0);
-      // add die explosion on 1 and keep the highest of the original number of die
-      if(data.overkill) d_roll.dice[die].modifiers.push("x1","kh{die.number}");
-    }
-    
+
     let droll: Roll | null;
     let tt: HTMLElement | JQuery | null;
     try {
-      droll = d_roll.roll();
+      droll = new Roll(x.val.toString());
+      
+      for (var die in droll.dice) {
+        // double the number of dice rolled on critical
+        if(attack_roll.total >= 20) droll.dice[die].alter(2, 0);
+        // add die explosion on 1 and keep the highest of the original number of die
+        if(data.overkill) droll.dice[die].modifiers.push("x1","kh{die.number}");
+      }
+      
+      droll = droll.roll();
       tt = await droll.getTooltip();
     } catch {
       droll = null;

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -415,10 +415,14 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
       droll = new Roll(x.val.toString());
       
       for (var die in droll.dice) {
+        // set an original die count
+        var die_count = die.number;
         // double the number of dice rolled on critical
         if(attack_roll.total >= 20) droll.dice[die].alter(2, 0);
         // add die explosion on 1 and keep the highest of the original number of die
-        if(data.overkill) droll.dice[die].modifiers.push("x1",`kh${die.number}`);
+        if(data.overkill) droll.dice[die].modifiers.push("x1");
+        // for both sections above, we want to keep the highest of the die count
+        droll.dice[die].modifiers.push(`kh${die_count}`);
       }
       
       droll = droll.roll();

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -418,7 +418,7 @@ async function rollAttackMacro(actor: Actor, data: LancerAttackMacroData) {
         // double the number of dice rolled on critical
         if(attack_roll.total >= 20) droll.dice[die].alter(2, 0);
         // add die explosion on 1 and keep the highest of the original number of die
-        if(data.overkill) droll.dice[die].modifiers.push("x1","kh{die.number}");
+        if(data.overkill) droll.dice[die].modifiers.push("x1",`kh${die.number}`);
       }
       
       droll = droll.roll();


### PR DESCRIPTION
This is meant to invoke the rule for rolling twice the number of dice, taking the highest of the original quantity, when the attack roll is twenty or higher.