### PR TITLE
[Incomplete] Partial fix for Actor item list removal.

### DIFF
--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -173,7 +173,7 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
       this._event_handler("reset-wep", evt);
     });
 
-    html.find(".reset-ll-weapon-mounts-button").on("click", async (evt: JQuery.ClickEvent) => {
+    html.find(".reset-all-weapon-mounts-button").on("click", async (evt: JQuery.ClickEvent) => {
       this._event_handler("reset-all-weapon-mounts", evt);
     });
 

--- a/src/module/helpers/commons.ts
+++ b/src/module/helpers/commons.ts
@@ -361,8 +361,11 @@ export function ext_helper_hash(
       // Splice out the value at path dest, then writeback
       array_path_edit(ctx.data, ctx.path, null, "delete");
     } else if (ctx.action == "null") {
+      let item = resolve_dotpath(ctx.data, ctx.path) as RegEntry<any>;
       // Null out the target space
       gentle_merge(ctx.data, { [ctx.path]: null });
+      //clean up item from item register.
+      item.destroy_entry();
     } else if (ctx.action == "set") {
       // Set the target space
       gentle_merge(ctx.data, { [ctx.path]: value });


### PR DESCRIPTION
Actor Item entries get destroyed after calling GenControlContext with data-action="null".

TODO: 
 -Items still left over from Mech Weapon Mounts being reset. 
 -Dropping Items Directly into Expected slots, leave ghost items with broken keys. 