### PR TITLE
Miscellaneous updates around the accuracy/difficulty dialog

### DIFF
--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2252,6 +2252,20 @@ div[data-tab="system"] > .settings-list > div:nth-last-child(-n + 4) {
   text-shadow: 0 0 8px red;
 }
 
+#sidebar a.chat-button {
+  animation: pulse 1200ms ease 1s 8 alternate;
+}
+
+@keyframes pulse {
+  0% {
+    text-shadow: none;
+  }
+  100% {
+    text-shadow: 0 0 8px red;
+  }
+}
+
+
 .cci-no-cover:before {
   content: '\25cb';
 }

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2094,6 +2094,39 @@ a.action {
   border-top: 1px solid #782e22;
 }
 
+.accdiff-base-cover {
+  margin-top: 12px;
+  margin-bottom: 4px;
+  font-size: 0.9em;
+  user-select: none;
+  padding-left: 5px;
+  line-height: 2;
+}
+
+.accdiff-targeted-cover label span {
+  opacity: 0;
+  position: fixed;
+  width: 0;
+  visibility: hidden;
+}
+
+.accdiff-targeted-cover label > i {
+  font-size: 16px;
+  vertical-align: top;
+}
+
+.accdiff-base-cover label > i {
+  vertical-align: baseline;
+}
+
+// there's a very specific foundry rule that adds some margin here
+// because it assumes all icons in buttons are followed by text, I think
+.accdiff-target-row button > i {
+  margin-inline-end: 0 !important; 
+}
+
+
+
 // V-IMPORTS
 .white--text {
   color: #fff !important;
@@ -2176,4 +2209,50 @@ div[data-tab="system"] > .settings-list > div:nth-last-child(-n + 4) {
 .chat-macro-button {
   max-width: 60%;
   align-self: center;
+}
+
+.accdiff-target-row .lancer-hit-thumb {
+  margin-right: 0px;
+  margin-left: 4px;
+  margin-bottom: 4px;
+}
+
+.lancer-cover-radio input[type="radio"] {
+  opacity: 0;
+  position: fixed;
+  width: 0;
+}
+
+.lancer-cover-radio label {
+  display: inline-block;
+  padding-left: 5px;
+}
+.lancer-cover-radio.flexrow label {
+  padding: 0px;
+}
+
+
+.lancer-cover-radio:not(.disabled) label:hover {
+  background-color: #dfd;
+}
+
+.lancer-cover-radio input[type="radio"]:checked + label {
+  background-color: #ddd;
+  .card & {
+    background-color: #aaa;
+  }
+}
+
+.lancer-cover-radio.disabled {
+  opacity: 0.6;
+}
+
+.cci-no-cover:before {
+  content: '\25cb';
+}
+.cci-soft-cover:before {
+  content: '\25d1';
+}
+.cci-hard-cover:before {
+  content: '\25cf';
 }

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2247,6 +2247,11 @@ div[data-tab="system"] > .settings-list > div:nth-last-child(-n + 4) {
   opacity: 0.6;
 }
 
+// needed to override a builtin that removes all shadows from the sidebar
+#sidebar a.chat-button:hover {
+  text-shadow: 0 0 8px red;
+}
+
 .cci-no-cover:before {
   content: '\25cb';
 }

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -657,9 +657,15 @@ Hooks.on("renderChatMessage", async (cm: ChatMessage, html: any, data: any) => {
   }
 
   html.find(".chat-button").on("click", (ev: MouseEvent) => {
-    ev.stopPropagation();
-    let element = ev.target as HTMLElement;
-    runEncodedMacro($(element));
+    function checkTarget(element: HTMLElement) {
+      if (element.attributes.getNamedItem('data-macro')) {
+        ev.stopPropagation();
+        runEncodedMacro($(element));
+        return true;
+      }
+      return false;
+    }
+    checkTarget(ev.target as HTMLElement) || checkTarget(ev.currentTarget as HTMLElement);
   })
 });
 

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -65,6 +65,8 @@ import {
   std_password_input,
   std_num_input,
   std_checkbox,
+  std_cover_input,
+  accdiff_total_display,
 } from "./module/helpers/commons";
 import {
   weapon_size_selector,
@@ -386,6 +388,8 @@ Hooks.once("init", async function () {
   Handlebars.registerHelper("std-num-input", std_num_input);
   Handlebars.registerHelper("std-checkbox", std_checkbox);
   Handlebars.registerHelper("action-button", action_button);
+  Handlebars.registerHelper("std-cover-input", std_cover_input);
+  Handlebars.registerHelper("accdiff-total-display", accdiff_total_display);
 
   // ------------------------------------------------------------------------
   // Tag helpers

--- a/src/module/helpers/acc_diff.ts
+++ b/src/module/helpers/acc_diff.ts
@@ -7,28 +7,191 @@ enum Cover {
   Hard = 2
 }
 
-export type AccDiffData = {
+type AccDiffBaseSerialized = {
+  untyped: { accuracy: number, difficulty: number },
+  cover: Cover,
+  accurate: boolean,
+  inaccurate: boolean,
+  seeking: boolean
+}
+
+type AccDiffTargetSerialized = {
+  target: string,
+  accuracy: number,
+  difficulty: number,
+  cover: Cover
+}
+
+export type AccDiffDataSerialized = {
   title: string,
-  base: {
-    untyped: {
-      accuracy: number,
-      difficulty: number,
-    },
-    accuracy: number,
-    difficulty: number,
-    cover: Cover,
-    accurate: boolean,
-    inaccurate: boolean,
-    seeking: boolean,
-    total: number
-  },
-  targets: {
+  base: AccDiffBaseSerialized,
+  targets: AccDiffTargetSerialized[],
+}
+
+class AccDiffBase {
+  untyped: { accuracy: number, difficulty: number };
+  cover: Cover;
+  accurate: boolean;
+  inaccurate: boolean;
+  seeking: boolean;
+
+  constructor(obj: AccDiffBaseSerialized) {
+    this.untyped = obj.untyped;
+    this.cover = obj.cover;
+    this.accurate = obj.accurate;
+    this.inaccurate = obj.inaccurate;
+    this.seeking = obj.seeking;
+  }
+
+  static fromObject(obj: AccDiffBaseSerialized): AccDiffBase {
+    return new AccDiffBase(obj);
+  }
+
+  toObject(): AccDiffBaseSerialized {
+    return {
+      untyped: this.untyped,
+      cover: this.cover,
+      accurate: this.accurate,
+      inaccurate: this.inaccurate,
+      seeking: this.seeking
+    }
+  }
+
+  get accuracy() {
+    return this.untyped.accuracy + (this.accurate ? 1 : 0);
+  }
+
+  get difficulty() {
+    return this.untyped.difficulty
+      + (this.inaccurate ? 1 : 0)
+      + (this.seeking ? 0 : this.cover)
+  }
+
+  get total() {
+    return this.accuracy - this.difficulty;
+  }
+}
+
+class AccDiffTarget {
+  target: Token;
+  accuracy: number;
+  difficulty: number;
+  cover: Cover;
+  #base: AccDiffBase;
+
+  constructor(obj: {
     target: Token,
     accuracy: number,
     difficulty: number,
-    cover: Cover,
-    total: number
-  }[],
+    cover: Cover
+  }, base: AccDiffBase) {
+    this.target = obj.target;
+    this.accuracy = obj.accuracy;
+    this.difficulty = obj.difficulty;
+    this.cover = obj.cover;
+    this.#base = base;
+  }
+
+  toObject(): AccDiffTargetSerialized {
+    return {
+      target: this.target.id,
+      accuracy: this.accuracy,
+      difficulty: this.difficulty,
+      cover: this.cover
+    }
+  }
+
+  static fromObject(obj: AccDiffTargetSerialized, base: AccDiffBase): AccDiffTarget {
+    let target = canvas.scene.tokens.get(obj.target);
+    if (!target) {
+      ui.notifications.error("Trying to access tokens from a different scene!");
+      throw new Error("Token not found");
+    }
+    return new AccDiffTarget({
+      target: target,
+      accuracy: obj.accuracy,
+      difficulty: obj.difficulty,
+      cover: obj.cover
+    }, base)
+  }
+
+  get total() {
+    return this.accuracy - this.difficulty
+      + this.#base.total - (this.#base.seeking ? 0 : this.cover);
+  }
+}
+
+export class AccDiffData {
+  title: string;
+  base: AccDiffBase;
+  targets: AccDiffTarget[];
+
+  constructor(obj: {
+    title: string,
+    base: AccDiffBase,
+    targets: AccDiffTarget[]
+  }) {
+    this.title = obj.title;
+    this.base = obj.base;
+    this.targets = obj.targets;
+  }
+
+  toObject(): AccDiffDataSerialized {
+    return {
+      title: this.title,
+      base: this.base.toObject(),
+      targets: this.targets.map(t => t.toObject())
+    }
+  }
+
+  static fromObject(obj: AccDiffDataSerialized): AccDiffData {
+    let base = AccDiffBase.fromObject(obj.base);
+    let targets = obj.targets.map(t => AccDiffTarget.fromObject(t, base));
+    return new AccDiffData({ title: obj.title, base, targets });
+  }
+
+  static fromParams(
+    tags?: TagInstance[],
+    title?: string,
+    targets?: Token[],
+    starting?: [number, number]
+  ): AccDiffData {
+    let base = AccDiffBase.fromObject({
+      accurate: false,
+      inaccurate: false,
+      cover: Cover.None,
+      seeking: false,
+      untyped: {
+        accuracy: starting ? starting[0] : 0,
+        difficulty: starting ? starting[1] : 0
+      },
+    });
+
+    for (let tag of (tags || [])) {
+      switch (tag.Tag.LID) {
+        case "tg_accurate":
+          base.accurate = true;
+          break;
+        case "tg_inaccurate":
+          base.inaccurate = true;
+          break;
+        case "tg_seeking":
+          base.seeking = true;
+          break;
+      }
+    }
+
+    return new AccDiffData({
+      title: title ? `${title} - Accuracy and Difficulty` : "Accuracy and Difficulty",
+      base: base,
+      targets: (targets || []).map(t => new AccDiffTarget({
+        target: t,
+        accuracy: 0,
+        difficulty: 0,
+        cover: Cover.None
+      }, base))
+    });
+  }
 }
 
 type AccDiffView = AccDiffData & {
@@ -46,74 +209,6 @@ export class AccDiffForm extends ReactiveForm<AccDiffData, AccDiffView> {
 
   constructor(data: AccDiffData) {
     super(data, { title: data.title })
-  }
-
-  static formDataFromParams(
-    tags?: TagInstance[],
-    title?: string,
-    targets?: Token[],
-    starting?: [number, number]
-  ): AccDiffData {
-    let ret: AccDiffData = {
-      title: title ? `${title} - Accuracy and Difficulty` : "Accuracy and Difficulty",
-      base: {
-        accurate: false,
-        inaccurate: false,
-        cover: Cover.None,
-        seeking: false,
-        untyped: {
-          accuracy: starting ? starting[0] : 0,
-          difficulty: starting ? starting[1] : 0
-        },
-        get accuracy() {
-          return this.untyped.accuracy + (this.accurate ? 1 : 0);
-        },
-        get difficulty() {
-          return this.untyped.difficulty
-            + (this.inaccurate ? 1 : 0)
-            + (this.seeking ? 0 : this.cover)
-        },
-        get total() {
-          return this.accuracy - this.difficulty;
-        }
-      },
-      targets: []
-    };
-
-    ret.targets = (targets || []).map(t => ({
-      target: t,
-      accuracy: 0,
-      difficulty: 0,
-      cover: Cover.None,
-      get total() {
-        return this.accuracy - this.difficulty
-          + ret.base.total - (ret.base.seeking ? 0 : this.cover);
-      }
-    }));
-
-    for (let tag of (tags || [])) {
-      switch (tag.Tag.LID) {
-        case "tg_accurate":
-          ret.base.accurate = true;
-          break;
-        case "tg_inaccurate":
-          ret.base.inaccurate = true;
-          break;
-        case "tg_seeking":
-          ret.base.seeking = true;
-          break;
-      }
-    }
-
-    return ret;
-  }
-
-  static fromData(
-    tags?: TagInstance[],
-    title?: string,
-    targets?: Token[],
-    starting?: [number, number]) {
-    return new AccDiffForm(AccDiffForm.formDataFromParams(tags, title, targets, starting));
   }
 
   getViewModel(data: AccDiffData): AccDiffView {

--- a/src/module/helpers/acc_diff.ts
+++ b/src/module/helpers/acc_diff.ts
@@ -1,101 +1,166 @@
 import { TagInstance } from "machine-mind";
+import { LancerActor, LancerActorType } from '../actor/lancer-actor';
+import { gentle_merge } from '../helpers/commons';
 
-export type AccDiffFlag = "ACCURATE" | "INACCURATE" | "SOFT_COVER" | "HARD_COVER" | "SEEKING";
-export const AccDiffRegistry: Record<AccDiffFlag, number> = {
-  ACCURATE: 1,
-  INACCURATE: -1,
-  SOFT_COVER: -1,
-  HARD_COVER: -2,
-  SEEKING: 0,
-};
-
-export function calcAccDiff() {
-  let acc = 0;
-  let diff = 0;
-  let flags: AccDiffFlag[] = [];
-  document
-    .querySelectorAll("[data-acc]:checked:not([disabled])")
-    .forEach(ele => flags.push(ele.getAttribute("data-acc") as AccDiffFlag));
-  document
-    .querySelectorAll("[data-diff]:checked:not([disabled])")
-    .forEach(ele => flags.push(ele.getAttribute("data-diff") as AccDiffFlag));
-
-  const isSeeking = flags.includes("SEEKING");
-  for (let flag of flags) {
-    switch (flag) {
-      case "SOFT_COVER":
-      case "HARD_COVER":
-        diff += isSeeking ? 0 : AccDiffRegistry[flag];
-        break;
-      case "ACCURATE":
-        acc += 1;
-        break;
-      case "INACCURATE":
-        diff -= 1;
-        break;
-      case "SEEKING":
-        break;
-    }
+export type AccDiffFormData = {
+  title: string,
+  baseUntypedAccDiff: { accuracy: number, difficulty: number },
+  baseAccDiff: { accuracy: number, difficulty: number },
+  targetedAccDiffs: { target: LancerActor<LancerActorType>, accuracy: number, difficulty: number }[],
+  accurate: boolean,
+  inaccurate: boolean,
+  softCover: boolean,
+  hardCover: boolean,
+  seeking: boolean,
+  seekingDisabled?: string,
+  totalIcon?: {
+    value: number,
+    color: string,
+    className: string
   }
-  return [acc, -diff];
 }
 
-function calcManualAccDiff() {
-  const acc = parseInt((document.querySelector(`#accdiff-other-acc`) as HTMLInputElement)?.value);
-  const diff = parseInt((document.querySelector(`#accdiff-other-diff`) as HTMLInputElement)?.value);
-  return [acc, diff];
-}
+export class AccDiffForm extends FormApplication {
+  data: AccDiffFormData;
+  resolve: ((data: AccDiffFormData) => void) | null = null;
+  reject: ((v: void) => void) | null = null;
+  promise: Promise<AccDiffFormData>;
 
-export function tagsToFlags(tags: TagInstance[]): AccDiffFlag[] {
-  const ret: AccDiffFlag[] = [];
-  tags.forEach(tag => {
-    switch (tag.Tag.LID) {
-      case "tg_accurate":
-        ret.push("ACCURATE");
-        break;
-      case "tg_inaccurate":
-        ret.push("INACCURATE");
-        break;
-      case "tg_seeking":
-        ret.push("SEEKING");
-        break;
-    }
-  });
-  return ret;
-}
-
-// DOM Manipulation
-export function toggleCover(toggle: boolean) {
-  const ret = document.querySelectorAll('[data-accdiff="SOFT_COVER"],[data-accdiff="HARD_COVER"]');
-  ret.forEach(ele => (toggle ? ele.removeAttribute("disabled") : ele.setAttribute("disabled", "true")));
-}
-
-export function updateTotals() {
-  const flags = calcAccDiff();
-  const other = calcManualAccDiff();
-  const totalAcc = flags[0] + other[0];
-  const totalDiff = flags[1] + other[1];
-  const fullTotal = totalAcc - totalDiff;
-
-  // SEPARATE SUBTOTALS
-  // const accEle = document.querySelector("#accdiff-total-acc");
-  // const diffEle = document.querySelector("#accdiff-total-diff");
-  // accEle && (accEle.innerHTML = String(totalAcc));
-  // diffEle && (diffEle.innerHTML = String(totalDiff));
-
-  // SINGLE TOTAL
-  const accEle = document.querySelector("#accdiff-total");
-  if (accEle) {
-    accEle.innerHTML = String(Math.abs(fullTotal));
-
-    // Change color based on result.
-    const color = fullTotal > 0 ? "#017934" : fullTotal < 0 ? "#9c0d0d" : "#443c3c";
-    accEle.parentElement!.style.backgroundColor = color;
-
-    // Change icon based on result.
-    fullTotal > 0 && accEle.nextElementSibling?.classList.replace("cci-difficulty", "cci-accuracy");
-    fullTotal < 0 && accEle.nextElementSibling?.classList.replace("cci-accuracy", "cci-difficulty");
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      template: "systems/lancer/templates/window/acc_diff.hbs",
+      resizable: false,
+      submitOnChange: false,
+      submitOnClose: false,
+      closeOnSubmit: true,
+    });
   }
 
-  return fullTotal;
+  constructor(data: AccDiffFormData) {
+    super(data, { title: data.title });
+    this.data = data;
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    })
+  }
+
+  static formDataFromParams(
+    tags?: TagInstance[],
+    title?: string,
+    targets?: LancerActor<LancerActorType>[],
+    starting?: [number, number]
+  ): AccDiffFormData {
+    let baseAccDiff = {
+      accuracy: starting ? starting[0] : 0,
+      difficulty: starting ? starting[1] : 0
+    };
+
+    let ret: AccDiffFormData = {
+      title: title ? `${title} - Accuracy and Difficulty` : "Accuracy and Difficulty",
+      baseUntypedAccDiff: baseAccDiff,
+      baseAccDiff: baseAccDiff, // this'll get overwritten by getData soon
+
+      targetedAccDiffs: (targets || []).map(t => ({
+        target: t,
+        accuracy: 0,
+        difficulty: 0
+      })),
+
+      accurate: false,
+      inaccurate: false,
+      softCover: false,
+      hardCover: false,
+      seeking: false
+    };
+
+    for (let tag of (tags || [])) {
+      switch (tag.Tag.LID) {
+        case "tg_accurate":
+          ret.accurate = true;
+          break;
+        case "tg_inaccurate":
+          ret.inaccurate = true;
+          break;
+        case "tg_seeking":
+          ret.seeking = true;
+          break;
+      }
+    }
+
+    return ret;
+  }
+
+  static fromData(
+    tags?: TagInstance[],
+    title?: string,
+    targets?: LancerActor<LancerActorType>[],
+    starting?: [number, number]) {
+    return new AccDiffForm(AccDiffForm.formDataFromParams(tags, title, targets, starting));
+  }
+
+  getData(): AccDiffFormData {
+    let ret = this.data;
+
+    ret.baseAccDiff = {
+      accuracy: ret.baseUntypedAccDiff.accuracy + (ret.accurate ? 1 : 0),
+      difficulty: ret.baseUntypedAccDiff.difficulty + (ret.inaccurate ? 1 : 0)
+    };
+    if (!ret.seeking && (ret.hardCover || ret.softCover)) {
+      ret.baseAccDiff.difficulty += ret.hardCover ? 2 : 1;
+    }
+
+    ret.seekingDisabled = ret.seeking ? "disabled" : "";
+
+    let total = ret.baseAccDiff.accuracy - ret.baseAccDiff.difficulty;
+
+    ret.totalIcon = {
+      value: Math.abs(total),
+      color: total > 0 ? "#017934" : total < 0 ? "#9c0d0d" : "#443c3c",
+      className: total >= 0 ? "cci-accuracy" : "cci-difficulty"
+    };
+
+    return ret;
+  }
+
+  activateListeners(html: JQuery) {
+    super.activateListeners(html);
+    html.find(".cancel").on("click", async (_ev) => {
+      return this.close();
+    });
+  }
+
+  async _onChangeInput(_e: Event) {
+    // @ts-ignore .8 -- FormApplication._onChangeInput does exist
+    await super._onChangeInput(_e);
+    // @ts-ignore .8 -- FormApplication._getSubmitData does exist
+    let data = this._getSubmitData(null);
+    await this._updateObject(_e, data);
+  }
+
+  _updateObject(ev: Event, formData: any) {
+    gentle_merge(this.data, formData);
+    this.render();
+
+    if (ev.type == "submit") {
+      if (this.resolve) {
+        this.resolve(this.data);
+        this.reject = null;
+      }
+      return this.promise;
+    } else {
+      return Promise.resolve(this.data);
+    }
+  }
+
+  // FormApplication.close() does take an options hash
+  // @ts-ignore .8
+  close(options: any = {}) {
+    if (this.reject) {
+      this.reject();
+      this.resolve = null;
+    };
+    // @ts-ignore .8
+    return super.close(options);
+  }
 }

--- a/src/module/helpers/acc_diff.ts
+++ b/src/module/helpers/acc_diff.ts
@@ -8,7 +8,7 @@ enum Cover {
   Hard = 2
 }
 
-export type AccDiffFormData = {
+export type AccDiffData = {
   title: string,
   base: {
     untyped: {
@@ -32,12 +32,12 @@ export type AccDiffFormData = {
   }[],
 }
 
-type AccDiffFormView = AccDiffFormData & {
+type AccDiffView = AccDiffData & {
   baseCoverDisabled: boolean,
   hasTargets: boolean
 }
 
-export class AccDiffForm extends ReactiveForm<AccDiffFormData, AccDiffFormView> {
+export class AccDiffForm extends ReactiveForm<AccDiffData, AccDiffView> {
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
       template: "systems/lancer/templates/window/acc_diff.hbs",
@@ -45,7 +45,7 @@ export class AccDiffForm extends ReactiveForm<AccDiffFormData, AccDiffFormView> 
     });
   }
 
-  constructor(data: AccDiffFormData) {
+  constructor(data: AccDiffData) {
     super(data, { title: data.title })
   }
 
@@ -54,8 +54,8 @@ export class AccDiffForm extends ReactiveForm<AccDiffFormData, AccDiffFormView> 
     title?: string,
     targets?: LancerActor<LancerActorType>[],
     starting?: [number, number]
-  ): AccDiffFormData {
-    let ret: AccDiffFormData = {
+  ): AccDiffData {
+    let ret: AccDiffData = {
       title: title ? `${title} - Accuracy and Difficulty` : "Accuracy and Difficulty",
       base: {
         accurate: false,
@@ -117,8 +117,8 @@ export class AccDiffForm extends ReactiveForm<AccDiffFormData, AccDiffFormView> 
     return new AccDiffForm(AccDiffForm.formDataFromParams(tags, title, targets, starting));
   }
 
-  getViewModel(data: AccDiffFormData): AccDiffFormView {
-    let ret = data as AccDiffFormView; // view elements haven't been set yet
+  getViewModel(data: AccDiffData): AccDiffView {
+    let ret = data as AccDiffView; // view elements haven't been set yet
     ret.hasTargets = ret.targets.length > 0;
     ret.baseCoverDisabled = ret.base.seeking || ret.hasTargets;
     return ret

--- a/src/module/helpers/acc_diff.ts
+++ b/src/module/helpers/acc_diff.ts
@@ -1,5 +1,4 @@
 import { TagInstance } from "machine-mind";
-import { LancerActor, LancerActorType } from '../actor/lancer-actor';
 import ReactiveForm from './reactive-form';
 
 enum Cover {
@@ -24,7 +23,7 @@ export type AccDiffData = {
     total: number
   },
   targets: {
-    target: LancerActor<LancerActorType>,
+    target: Token,
     accuracy: number,
     difficulty: number,
     cover: Cover,
@@ -52,7 +51,7 @@ export class AccDiffForm extends ReactiveForm<AccDiffData, AccDiffView> {
   static formDataFromParams(
     tags?: TagInstance[],
     title?: string,
-    targets?: LancerActor<LancerActorType>[],
+    targets?: Token[],
     starting?: [number, number]
   ): AccDiffData {
     let ret: AccDiffData = {
@@ -112,7 +111,7 @@ export class AccDiffForm extends ReactiveForm<AccDiffData, AccDiffView> {
   static fromData(
     tags?: TagInstance[],
     title?: string,
-    targets?: LancerActor<LancerActorType>[],
+    targets?: Token[],
     starting?: [number, number]) {
     return new AccDiffForm(AccDiffForm.formDataFromParams(tags, title, targets, starting));
   }

--- a/src/module/helpers/automation/targeting.ts
+++ b/src/module/helpers/automation/targeting.ts
@@ -1,6 +1,6 @@
 import { LancerActor, LancerActorType } from "../../actor/lancer-actor";
 
-export function getTargets(): LancerActor<LancerActorType>[] {
+export function getTargetActors(): LancerActor<LancerActorType>[] {
   const targets = game.user.targets;
   const ret: LancerActor<LancerActorType>[] = [];
   targets.forEach(token => {

--- a/src/module/helpers/commons.ts
+++ b/src/module/helpers/commons.ts
@@ -505,6 +505,74 @@ async function control_structs(key: string, on: LiveEntryTypes<EntryType>): Prom
   return [false, null];
 }
 
+export function std_cover_input(path: string, options: HelperOptions) {
+  let container_classes: string = options.hash["classes"] || "";
+  let label: string = options.hash["label"] || "";
+  let label_classes: string = options.hash["label_classes"] || "";
+
+  let value: string | undefined = options.hash["value"];
+  if (value == undefined) {
+    // Resolve
+    value = (resolve_helper_dotpath(options, path) as number)?.toString() ?? 0;
+  }
+
+  let checked = ["0", "1", "2"].map(v => value == v ? "checked='true'" : "");
+  let disabled: boolean = options.hash["disabled"] ? resolve_helper_dotpath(options, options.hash["disabled"]) : false;
+  let disabledStr = disabled ? "disabled" : "";
+
+  let inputs = [
+    `<input type="radio" id="${path}-cover-none" class="no-grow cover-none" name="${path}" value="0" ${checked[0]} data-dtype="Number" ${disabledStr} />
+     <label for="${path}-cover-none" class="lancer-cover-radio-label ${label_classes}">
+       <i class="cci-no-cover i--s" style="border:none"></i>
+       <span class="no-grow">No Cover</span>
+     </label>`,
+    `<input type="radio" id="${path}-cover-soft" class="no-grow cover-soft" name="${path}" value="1" ${checked[1]} data-dtype="Number" ${disabledStr} />
+    <label for="${path}-cover-soft" class="lancer-cover-radio-label ${label_classes}">
+       <i class="cci-soft-cover i--s" style="border:none"></i>
+       <span class="no-grow">Soft Cover (-1)</span>
+     </label>`,
+    `<input type="radio" id="${path}-cover-hard" class="no-grow cover-hard" name="${path}" value="2" ${checked[2]} data-dtype="Number" ${disabledStr} />
+     <label for="${path}-cover-hard" class="lancer-cover-radio-label ${label_classes}">
+       <i class="cci-hard-cover i--s" style="border:none"></i>
+       <span class="no-grow">Hard Cover (-2)</span>
+     </label>`
+  ];
+
+  if (label) {
+    return `<label class="lancer-cover-radio ${disabledStr} ${label_classes} ${container_classes}">
+              <span class="no-grow" style="padding: 2px 5px;">${label}</span>
+              ${inputs.join(" ")}
+            </label>`
+  } else {
+    return `<div class="lancer-cover-radio ${disabledStr} ${container_classes}">${inputs.join(" ")}</div>`;
+  }
+}
+
+export function accdiff_total_display(path: string, options: HelperOptions) {
+  let container_classes: string = options.hash["classes"] || "";
+  let id: string = options.hash["id"] || "";
+  let value: string | undefined = options.hash["value"];
+  let total = 0;
+  if (value == undefined) {
+    // Resolve
+    total = (resolve_helper_dotpath(options, path) as number) ?? 0;
+  }
+
+  let abs = Math.abs(total);
+  let color = total > 0 ? "#017934" : total < 0 ? "#9c0d0d" : "#443c3c";
+  let icon = total >= 0 ? "cci-accuracy" : "cci-difficulty"
+
+  return `
+<div class="${container_classes}">
+  <div>
+    <div class="card clipped" style="background-color: ${color}">
+      <span id="${id}">${abs}</span>
+      <i class="cci ${icon} i--m i--dark white--text" style="vertical-align:middle;border:none"></i>
+    </div>
+  </div>
+</div>`
+}
+
 // Our standardized functions for making simple key-value input pair
 // Todo - these could on the whole be a bit fancier, yeah?
 

--- a/src/module/helpers/reactive-form.ts
+++ b/src/module/helpers/reactive-form.ts
@@ -1,0 +1,84 @@
+import { gentle_merge } from '../helpers/commons';
+
+// this captures a useful pattern where we want to make a reactive form
+// that is rooted on "raw data" rather than a Foundry Document
+// to access the data from outside it, use the .promise property
+// it is resolved when the user clicks submit, and rejected if the form is closed otherwise
+// assumptions:
+// * the name attributes in the html form directly match the keys in the raw data
+//     (modulo gentle_merge)
+// * the template contains precisely one HTML form as its outermost element
+export default abstract class ReactiveForm<DataModel, ViewModel extends DataModel> extends FormApplication {
+  // FormApplication defines this and sets it in the constructor
+  object!: DataModel;
+
+  #resolve: ((data: DataModel) => void) | null = null;
+  #reject: ((v: void) => void) | null = null;
+  promise: Promise<DataModel>;
+
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      submitOnChange: false,
+      submitOnClose: false,
+      closeOnSubmit: true,
+    });
+  }
+
+  constructor(data: DataModel, options: FormApplicationOptions) {
+    super(data, options);
+    this.promise = new Promise((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+    })
+  }
+
+  abstract getViewModel(data: DataModel): ViewModel;
+
+  getData(): ViewModel {
+    let ret: DataModel = this.object;
+    return this.getViewModel(ret);
+  }
+
+  // cancel buttons need explicit handling
+  activateListeners(html: JQuery) {
+    super.activateListeners(html);
+    html.find(".cancel").on("click", async (_ev) => {
+      return this.close();
+    });
+  }
+
+  async _onChangeInput(_e: Event) {
+    // @ts-ignore .8 -- FormApplication._onChangeInput does exist
+    await super._onChangeInput(_e);
+    // @ts-ignore .8 -- FormApplication._getSubmitData does exist
+    let data = this._getSubmitData(null);
+    await this._updateObject(_e, data);
+  }
+
+  // requires the names in the template to match
+  _updateObject(ev: Event, formData: any) {
+    gentle_merge(this.object, formData);
+    this.render();
+
+    if (ev.type == "submit") {
+      if (this.#resolve) {
+        this.#resolve(this.object);
+        this.#reject = null;
+      }
+      return this.promise;
+    } else {
+      return Promise.resolve(this.object);
+    }
+  }
+
+  // FormApplication.close() does take an options hash
+  // @ts-ignore .8
+  close(options: any = {}) {
+    if (this.#reject) {
+      this.#reject();
+      this.#resolve = null;
+    };
+    // @ts-ignore .8
+    return super.close(options);
+  }
+}

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -450,8 +450,7 @@ function getMacroActorItem(a: string, i: string): { actor: Actor | null; item: I
   return result;
 }
 
-function rollStr(bonus: number, obj: { accuracy: number, difficulty: number }): string {
-  let total = obj.accuracy - obj.difficulty;
+function rollStr(bonus: number, total: number): string {
   let modStr = "";
   if (total != 0) {
     let sign = total > 0 ? "+" : "-";
@@ -477,13 +476,10 @@ async function buildAttackRollStrings(
   try {
     let accdiff = await promptAccDiffModifiers(tags, title, targets, starting);
     let res: AttackRoll = {
-      roll: rollStr(bonus, accdiff.baseAccDiff),
-      targeted: accdiff.targetedAccDiffs.map(tad => ({
+      roll: rollStr(bonus, accdiff.base.total),
+      targeted: accdiff.targets.map(tad => ({
         target: tad.target,
-        roll: rollStr(bonus, {
-          accuracy: tad.accuracy + accdiff.baseAccDiff.accuracy,
-          difficulty: tad.difficulty + accdiff.baseAccDiff.difficulty
-        })
+        roll: rollStr(bonus, tad.total)
       }))
     };
 
@@ -529,7 +525,7 @@ async function rollStatMacro(actor: Actor, data: LancerStatMacroData) {
   let acc: number = 0;
   let abort: boolean = false;
   await promptAccDiffModifiers().then(
-    accdiff => (acc = accdiff.baseAccDiff.accuracy - accdiff.baseAccDiff.difficulty),
+    accdiff => (acc = accdiff.base.total),
     () => (abort = true)
   );
   if (abort) return Promise.resolve();

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -523,12 +523,13 @@ async function rollStatMacro(actor: Actor, data: LancerStatMacroData) {
 
   // Get accuracy/difficulty with a prompt
   let acc: number = 0;
-  let abort: boolean = false;
-  await promptAccDiffModifiers().then(
-    accdiff => (acc = accdiff.base.total),
-    () => (abort = true)
-  );
-  if (abort) return Promise.resolve();
+  try {
+    let accdiff = await promptAccDiffModifiers();
+    acc = accdiff.base.total;
+  } catch {
+    // an error occurred during the prompt; probably the user cancelling
+    return Promise.resolve();
+  }
 
   // Do the roll
   let acc_str = acc != 0 ? ` + ${acc}d6kh1` : "";

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -508,7 +508,7 @@ async function rollStatMacro(actor: Actor, data: LancerStatMacroData) {
   if (!actor) return Promise.resolve();
 
   // Get accuracy/difficulty with a prompt
-  let initialData = AccDiffForm.formDataFromParams();
+  let initialData = AccDiffData.fromParams();
   let promptedData = await promptAccDiffModifiers(initialData);
   if (!promptedData) return;
   let acc: number = promptedData.base.total;
@@ -697,7 +697,7 @@ async function prepareAttackMacro({
 
   // Prompt the user before deducting charges.
   const targets = Array.from(game.user.targets);
-  const initialData = rerollData ?? AccDiffForm.formDataFromParams(
+  const initialData = rerollData ?? AccDiffData.fromParams(
     mData.tags, mData.title, targets, mData.acc > 0 ? [mData.acc, 0] : [0, -mData.acc]);
   const promptedData = await promptAccDiffModifiers(initialData);
   if (!promptedData) return;
@@ -1104,7 +1104,7 @@ export async function prepareTechMacro(a: string, t: string) {
 
 async function rollTechMacro(actor: Actor, data: LancerTechMacroData, rerollData?: AccDiffData) {
   const targets = Array.from(game.user.targets);
-  const initialData = rerollData ?? AccDiffForm.formDataFromParams(data.tags, data.title, targets);
+  const initialData = rerollData ?? AccDiffData.fromParams(data.tags, data.title, targets);
   const promptedData = await promptAccDiffModifiers(initialData);
   if (!promptedData) return;
 

--- a/src/templates/chat/attack-card.hbs
+++ b/src/templates/chat/attack-card.hbs
@@ -2,6 +2,9 @@
   <div class="lancer-header mech_weapon medium">
     <i class="cci cci-weapon i--m i--light"> </i>
     <span>{{ title }}</span>
+    <a class="chat-button roll-attack" data-macro="{{rerollMacroData}}" title="Reroll this attack">
+      <i class="fas fa-dice-d20 i--m i--light"></i>
+    </a>
   </div>
   <div class="card clipped">
     <div class="lancer-mini-header collapse-trigger" data-collapse-id="{{_uuid}}-attacks">{{localize "lancer.chat-card.title.attack"}}</div>

--- a/src/templates/chat/tech-attack-card.hbs
+++ b/src/templates/chat/tech-attack-card.hbs
@@ -8,10 +8,7 @@
       {{localize "lancer.chat-card.title.attack"}}
     </div>
     {{#each attacks as |attack key|}}
-    <div
-      class="dice-roll lancer-dice-roll collapse{{#if ../hits}} collapsed{{/if}}"
-      data-collapse-id="{{../_uuid}}-attacks"
-    >
+    <div class="dice-roll lancer-dice-roll">
       <div class="dice-result">
         <div class="dice-formula lancer-dice-formula flexrow">
           <span style="text-align: left; margin-left: 5px;">{{ attack.roll.formula }}</span>

--- a/src/templates/window/acc_diff.hbs
+++ b/src/templates/window/acc_diff.hbs
@@ -1,107 +1,121 @@
-<div id="accdiff-dialog" style="padding:4px">
-  <div class="accdiff-grid">
-    <div style="width:100%;padding:4px;border-right: 1px dashed #782e22;">
-      <h3>
-        <i class="cci cci-accuracy i--m i--dark" style="vertical-align:middle;border:none"></i>
-        Accuracy
-      </h3>
-      <label class="container">
-        Accurate (+1)
-        <input type="checkbox" data-acc="ACCURATE" />
-        <span class="checkmark"></span>
-      </label>
-      <label class="container">
-        Seeking (*)
-        <input type="checkbox" data-acc="SEEKING" />
-        <span class="checkmark"></span>
-      </label>
+<form>
+  <div id="accdiff-dialog" style="padding:4px">
+    <div class="accdiff-grid">
+      <div style="width:100%;padding:4px;border-right: 1px dashed #782e22;">
+        <h3>
+          <i class="cci cci-accuracy i--m i--dark" style="vertical-align:middle;border:none"></i>
+          Accuracy
+        </h3>
+        <label class="container">
+          Accurate (+1)
+          <input type="checkbox" name="accurate" {{checked accurate}} />
+          <span class="checkmark"></span>
+        </label>
+        <label class="container">
+          Seeking (*)
+          <input type="checkbox" name="seeking" {{checked seeking}} />
+          <span class="checkmark"></span>
+        </label>
+      </div>
+      <div style="width:100%;padding:4px;">
+        <h3>
+          <i class="cci cci-difficulty i--m i--dark" style="vertical-align:middle;border:none"></i>
+          Difficulty
+        </h3>
+        <label class="container">
+          Inaccurate (-1)
+          <input type="checkbox" name="inaccurate" {{checked inaccurate}} />
+          <span class="checkmark"></span>
+        </label>
+        <label class="container">
+          Soft Cover (-1)
+          <input type="checkbox" name="softCover" {{checked softCover}} {{seekingDisabled}} />
+          <span class="checkmark"></span>
+        </label>
+        <label class="container">
+          Hard Cover (-2)
+          <input type="checkbox" name="hardCover" {{checked hardCover}} {{seekingDisabled}} />
+          <span class="checkmark"></span>
+        </label>
+      </div>
     </div>
-    <div style="width:100%;padding:4px;">
-      <h3>
-        <i class="cci cci-difficulty i--m i--dark" style="vertical-align:middle;border:none"></i>
-        Difficulty
-      </h3>
-      <label class="container">
-        Inaccurate (-1)
-        <input type="checkbox" data-diff="INACCURATE" />
-        <span class="checkmark"></span>
-      </label>
-      <label class="container">
-        Soft Cover (-1)
-        <input type="checkbox" data-diff="SOFT_COVER" />
-        <span class="checkmark"></span>
-      </label>
-      <label class="container">
-        Hard Cover (-2)
-        <input type="checkbox" data-diff="HARD_COVER" />
-        <span class="checkmark"></span>
-      </label>
+    <label class="flexrow accdiff-footer accdiff-weight">
+      Other Sources
+    </label>
+    <div class="accdiff-grid">
+      <div class="accdiff-other-grid" style="border-right: 1px dashed #782e22;">
+        <button
+          class="mod-minus-button dec-set"
+          type="button"
+          onclick="this.nextElementSibling.value = this.nextElementSibling.valueAsNumber - 1; this.nextElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+        >
+          -
+        </button>
+        <input
+          id="accdiff-other-acc"
+          class="difficulty lancer-invisible-input dec-set"
+          style="max-width: 2em;text-align: center;font-size: 1.2em"
+          type="number"
+          name="baseUntypedAccDiff.accuracy"
+          value="{{baseUntypedAccDiff.accuracy}}"
+          min="0"
+        />
+        <button
+          class="mod-plus-button dec-set"
+          type="button"
+          onclick="this.previousElementSibling.value = this.previousElementSibling.valueAsNumber + 1; this.previousElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+        >
+          +
+        </button>
+      </div>
+      <div class="accdiff-other-grid">
+        <button
+          class="mod-minus-button dec-set"
+          type="button"
+          onclick="this.nextElementSibling.value = this.nextElementSibling.valueAsNumber - 1; this.nextElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+        >
+          -
+        </button>
+        <input
+          id="accdiff-other-diff"
+          class="difficulty lancer-invisible-input dec-set"
+          style="max-width: 2em;text-align: center;font-size: 1.2em"
+          type="number"
+          name="baseUntypedAccDiff.difficulty"
+          value="{{baseUntypedAccDiff.difficulty}}"
+          min="0"
+        />
+        <button
+          class="mod-plus-button dec-set"
+          type="button"
+          onclick="this.previousElementSibling.value = this.previousElementSibling.valueAsNumber + 1; this.previousElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+        >
+          +
+        </button>
+      </div>
     </div>
-  </div>
-  <label class="flexrow accdiff-footer accdiff-weight">
-    Other Sources
-  </label>
-  <div class="accdiff-grid">
-    <div class="accdiff-other-grid" style="border-right: 1px dashed #782e22;">
-      <button
-        class="mod-minus-button dec-set"
-        type="button"
-        onclick="this.nextElementSibling.value = this.nextElementSibling.valueAsNumber - 1"
-      >
-        -
-      </button>
-      <input
-        id="accdiff-other-acc"
-        class="difficulty lancer-invisible-input dec-set"
-        style="max-width: 2em;text-align: center;font-size: 1.2em"
-        type="number"
-        value="0"
-        min="0"
-      />
-      <button
-        class="mod-plus-button dec-set"
-        type="button"
-        onclick="this.previousElementSibling.value = this.previousElementSibling.valueAsNumber + 1"
-      >
-        +
-      </button>
-    </div>
-    <div class="accdiff-other-grid">
-      <button
-        class="mod-minus-button dec-set"
-        type="button"
-        onclick="this.nextElementSibling.value = this.nextElementSibling.valueAsNumber - 1"
-      >
-        -
-      </button>
-      <input
-        id="accdiff-other-diff"
-        class="difficulty lancer-invisible-input dec-set"
-        style="max-width: 2em;text-align: center;font-size: 1.2em"
-        type="number"
-        value="0"
-        min="0"
-      />
-      <button
-        class="mod-plus-button dec-set"
-        type="button"
-        onclick="this.previousElementSibling.value = this.previousElementSibling.valueAsNumber + 1"
-      >
-        +
-      </button>
-    </div>
-  </div>
-  <label class="flexrow accdiff-footer accdiff-weight">
-    Total
-  </label>
-  <div class="accdiff-grid accdiff-weight">
-    <div>
-      <div class="card clipped">
-        <span id="accdiff-total">
-          0
-        </span>
-        <i class="cci cci-accuracy i--m i--dark white--text" style="vertical-align:middle;border:none"></i>
+    <label class="flexrow accdiff-footer accdiff-weight">
+      Total
+    </label>
+    <div class="accdiff-grid accdiff-weight">
+      <div>
+        <div class="card clipped" style="background-color: {{totalIcon.color}}">
+          <span id="accdiff-total">
+            {{totalIcon.value}}
+          </span>
+          <i class="cci {{totalIcon.className}} i--m i--dark white--text" style="vertical-align:middle;border:none"></i>
+        </div>
       </div>
     </div>
   </div>
-</div>
+  <div class="dialog-buttons flexrow">
+    <button class="dialog-button submit default" data-button="submit" type="submit">
+      <i class="fas fa-check"></i>
+      Roll
+    </button>
+    <button class="dialog-button cancel" data-button="cancel" type="button">
+      <i class="fas fa-times"></i>
+      Cancel
+    </button>
+  </div>
+</form>

--- a/src/templates/window/acc_diff.hbs
+++ b/src/templates/window/acc_diff.hbs
@@ -1,4 +1,4 @@
-<form>
+<form id="accdiff">
   <div id="accdiff-dialog" style="padding:4px">
     <div class="accdiff-grid">
       <div style="width:100%;padding:4px;border-right: 1px dashed #782e22;">
@@ -8,12 +8,12 @@
         </h3>
         <label class="container">
           Accurate (+1)
-          <input type="checkbox" name="accurate" {{checked accurate}} />
+          <input type="checkbox" name="base.accurate" {{checked base.accurate}} />
           <span class="checkmark"></span>
         </label>
         <label class="container">
           Seeking (*)
-          <input type="checkbox" name="seeking" {{checked seeking}} />
+          <input type="checkbox" name="base.seeking" {{checked base.seeking}} />
           <span class="checkmark"></span>
         </label>
       </div>
@@ -24,19 +24,13 @@
         </h3>
         <label class="container">
           Inaccurate (-1)
-          <input type="checkbox" name="inaccurate" {{checked inaccurate}} />
+          <input type="checkbox" name="base.inaccurate" {{checked base.inaccurate}} />
           <span class="checkmark"></span>
         </label>
-        <label class="container">
-          Soft Cover (-1)
-          <input type="checkbox" name="softCover" {{checked softCover}} {{seekingDisabled}} />
-          <span class="checkmark"></span>
-        </label>
-        <label class="container">
-          Hard Cover (-2)
-          <input type="checkbox" name="hardCover" {{checked hardCover}} {{seekingDisabled}} />
-          <span class="checkmark"></span>
-        </label>
+        {{{std-cover-input "base.cover"
+          classes="accdiff-base-cover flexcol"
+          disabled="baseCoverDisabled"
+        }}}
       </div>
     </div>
     <label class="flexrow accdiff-footer accdiff-weight">
@@ -56,8 +50,8 @@
           class="difficulty lancer-invisible-input dec-set"
           style="max-width: 2em;text-align: center;font-size: 1.2em"
           type="number"
-          name="baseUntypedAccDiff.accuracy"
-          value="{{baseUntypedAccDiff.accuracy}}"
+          name="base.untyped.accuracy"
+          value="{{base.untyped.accuracy}}"
           min="0"
         />
         <button
@@ -81,8 +75,8 @@
           class="difficulty lancer-invisible-input dec-set"
           style="max-width: 2em;text-align: center;font-size: 1.2em"
           type="number"
-          name="baseUntypedAccDiff.difficulty"
-          value="{{baseUntypedAccDiff.difficulty}}"
+          name="base.untyped.difficulty"
+          value="{{base.untyped.difficulty}}"
           min="0"
         />
         <button
@@ -94,19 +88,73 @@
         </button>
       </div>
     </div>
-    <label class="flexrow accdiff-footer accdiff-weight">
-      Total
-    </label>
-    <div class="accdiff-grid accdiff-weight">
-      <div>
-        <div class="card clipped" style="background-color: {{totalIcon.color}}">
-          <span id="accdiff-total">
-            {{totalIcon.value}}
-          </span>
-          <i class="cci {{totalIcon.className}} i--m i--dark white--text" style="vertical-align:middle;border:none"></i>
-        </div>
+    {{#unless hasTargets}}
+      <label class="flexrow accdiff-footer accdiff-weight">
+        Total
+      </label>
+      {{{accdiff-total-display "base.total"
+        id="accdiff-total"
+        classes="accdiff-grid accdiff-weight"
+      }}}
+    {{/unless}}
+    {{#if hasTargets}}
+      <div class="flexrow accdiff-footer accdiff-weight accdiff-grid accdiff-target-row">
+        {{#each targets as |data key|}}
+          <div class="flexcol card">
+            <label class="flexrow flex-center card">
+              {{data.target.data.name}}
+            </label>
+            <div class="flexrow">
+              <div class="accdiff-grid accdiff-weight">
+                <img class="lancer-hit-thumb" src="{{data.target.data.img}}" />
+              </div>
+              {{{accdiff-total-display (concat "targets." key ".total")
+                id=(concat "accdiff-total-" key)
+                classes="accdiff-grid accdiff-weight"
+              }}}
+            </div>
+            <div class="flexrow">
+              <button
+                class="i--m no-grow"
+                type="button"
+                onclick="this.nextElementSibling.value = this.nextElementSibling.valueAsNumber + 1; this.nextElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+              >
+                <i class="cci cci-accuracy i--m" style="border:none"></i>
+              </button>
+              <input
+                id="accdiff-other-acc-{{key}}"
+                style="display: none"
+                type="number"
+                name="targets.{{key}}.accuracy"
+                value="{{data.accuracy}}"
+                min="0"
+              />
+              {{{std-cover-input (concat "targets." key ".cover")
+                classes="accdiff-targeted-cover flexrow flex-center"
+                label_classes="i--s"
+                container_classes="f-16"
+                disabled="base.seeking"
+              }}}
+              <input
+                id="accdiff-other-diff-{{key}}"
+                style="display: none"
+                type="number"
+                name="targets.{{key}}.difficulty"
+                value="{{data.difficulty}}"
+                min="0"
+              />
+              <button
+                class="i--m no-grow"
+                type="button"
+                onclick="this.previousElementSibling.value = this.previousElementSibling.valueAsNumber + 1; this.previousElementSibling.dispatchEvent(new Event('change', {bubbles: true}))"
+              >
+                <i class="cci cci-difficulty i--m" style="border:none"></i>
+              </button>
+            </div>
+          </div>
+        {{/each}}
       </div>
-    </div>
+    {{/if}}
   </div>
   <div class="dialog-buttons flexrow">
     <button class="dialog-button submit default" data-button="submit" type="submit">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66472/125557848-4caa41a3-0a33-4480-a5b3-3c8da2a030e0.png)
![image](https://user-images.githubusercontent.com/66472/125557870-452129e9-0fc0-4121-bf5d-d80b05622f7d.png)

The main user-facing elements of this branch are the new multi-targetting UI in `acc_dff.ts` and the reroll button on the top right of attack rolls. The reroll button pulses for a few seconds on new chat messages; hopefully subtly but also not forever, to aid discoverability.

Additionally:
* `ReactiveForm`, an abstract class that can handle reactive handlebars updates on arbitrary javascript data
* the accdiff dialog is handlebars'd, using the above
* `{{std-cover-input}}`, a handlebars helper for selecting cover
* `{{accdiff-total-display}}`, a handlebars helper for displaying a summed accuracy/difficulty
* some slight updates to rollstring generation
* some slight code simplification in the attack/tech attack macros
* accdiff now has access to the tokens, potentially easing the way to checking token effects
* accdiff form data is serializable, which we use with `runEncodedMacro` to remember selections in the form for the reroll
* a bugfix on the `runEncodedMacro` logic such that the entire target can be clicked 

Next steps:
[ ] Finalise a UI for rerolls
[ ] Implement rerolls for tech attacks