### PR TITLE
minify and split out source maps in production

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,10 +123,11 @@ const tsConfig = ts.createProject("tsconfig.json", {
 
 let webpackConfig = shouldWatch => {
   return {
+    mode: shouldWatch ? "development" : "production",
     entry: "./src/lancer.ts",
-    devtool: "inline-source-map",
+    devtool: shouldWatch ? "inline-source-map" : "source-map",
     optimization: {
-      minimize: false,
+      minimize: !shouldWatch,
     },
     module: {
       rules: [


### PR DESCRIPTION
14mb (~4mb gzipped) entrypoint down to 2mb (~600kb gzipped). `gulp watch` uses the existing devbuild, `gulp build` uses this production build.