### PR TITLE
handle new comp/con vault ids (also #216, #252, #256, #261)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,10 +139,15 @@ let webpackConfig = shouldWatch => {
           test: /\.css$/i,
           use: ["style-loader", "css-loader"],
         },
+        {
+          test: /\.mjs$/i,
+          include: /node_modules/,
+          type: 'javascript/auto',
+        }
       ],
     },
     resolve: {
-      extensions: [".ts", ".tsx", ".js"],
+      extensions: [".ts", ".tsx", ".js", ".mjs"],
     },
     output: {
       filename: "lancer.js",

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -131,7 +131,7 @@ import { applyCollapseListeners } from "./module/helpers/collapse";
 import { handleCombatUpdate } from "./module/helpers/automation/combat";
 import { handleActorExport, validForExport } from "./module/helpers/io";
 import { runEncodedMacro, prepareTextMacro } from './module/macros';
-import { fix_modify_token_attribute, LancerToken, LancerTokenDocument } from "./module/token";
+import { LancerToken, LancerTokenDocument } from "./module/token";
 
 const lp = LANCER.log_prefix;
 
@@ -661,10 +661,6 @@ Hooks.on("renderChatMessage", async (cm: ChatMessage, html: any, data: any) => {
 
 Hooks.on("hotbarDrop", (_bar: any, data: any, slot: number) => {
   macros.onHotbarDrop(_bar, data, slot);
-});
-
-Hooks.on("modifyTokenAttribute", (_: any, data: any) => {
-  fix_modify_token_attribute(data);
 });
 
 /**

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -96,6 +96,7 @@
                 "effect": "// EFFECT //",
                 "charge-roll": "// CHARGE ROLL //",
                 "changes": "// CHANGES //",
+                "structure": "// STRUCTURE DAMAGE //",
                 "overheating": "// OVERHEATING //",
                 "check": "// CHECK :: {check} //",
                 "system": "// SYSTEM :: {system} //"

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -59,7 +59,7 @@
             "cloud-header": {
                 "label": "RM-4://(OMNINET UPLINK ID)",
                 "vaultID": "Load from your Comp/Con account (if logged in)",
-                "gist-placeholder": "or enter an old cloud share code"
+                "raw-placeholder": "or enter a code manually"
             },
             "cloud-download": {
                 "label": "DOWNLOAD",

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -627,7 +627,7 @@ export class LancerActor<T extends LancerActorType> extends Actor {
     return return_text;
   }
 
-  // Imports an old-style compcon pilot sync code
+  // Imports packed pilot data, from either a vault id or gist id
   async importCC(data: PackedPilotData, clearFirst = false) {
     if (this.data.type !== "pilot") {
       return;
@@ -725,10 +725,15 @@ export class LancerActor<T extends LancerActorType> extends Actor {
         // Rename and rehome mechs
         sync_mech: (mech: Mech) => {
           let flags = mech.Flags as FoundryFlagData<EntryType.MECH>;
+          let portrait = mech.CloudPortrait || mech.Frame?.ImageUrl || "";
+          let new_img = replace_default_resource(flags.top_level_data["img"], portrait);
           flags.top_level_data["name"] = mech.Name;
           flags.top_level_data["folder"] = unit_folder ? unit_folder.id : null;
           flags.top_level_data["token.name"] = data.callsign;
+          flags.top_level_data["img"] = new_img;
+          flags.top_level_data["token.img"] = new_img;
           flags.top_level_data["permission"] = permission;
+          mech.writeback();
           // TODO: Retrogrades
         },
         // Set pilot token

--- a/src/module/compcon.ts
+++ b/src/module/compcon.ts
@@ -1,36 +1,59 @@
 import { PackedPilotData } from "machine-mind";
 import Auth from "@aws-amplify/auth";
 import Storage from "@aws-amplify/storage";
+import { CachedCloudPilot } from "./interfaces";
 
-// we don't cache anything other than id/name; we're going to fetch all other data on user input
-// but we don't want the pilot actor window to wait for network calls
+// we only cache the id, cloud ids, and name; we're going to fetch all other data on user input
+// the point of the cache is not have the pilot actor window to wait for network calls
 // this does mean that the GM needs to refresh foundry to clear this cache if they add pilots
 // (they could also re-login, we initiate a cache refresh there)
-let pilotCache: Array<{ id: string; name: string }> = [];
 
-export async function populatePilotCache(): Promise<Array<{ id: string; name: string }>> {
+let _cache: CachedCloudPilot[] = [];
+
+export function cleanCloudOwnerID(str: string): string {
+  return str.substring(0, 10) == 'us-east-1:' ? str.substring(10) : str
+}
+
+export async function populatePilotCache(): Promise<CachedCloudPilot[]> {
   await Auth.currentSession(); // refresh the token if we need to
   const res = await Storage.list("pilot", { level: "protected" });
-  const data: Array<PackedPilotData> = await Promise.all(res.map((obj: { key: string }) => fetchPilot(obj.key)));
-  data.forEach(pilot => (pilot.mechs = []));
-  pilotCache = data;
+  const data: Array<PackedPilotData> =
+    await Promise.all(res.map((obj: { key: string }) => fetchPilot(obj.key)));
+  data.forEach(pilot => {
+    pilot.mechs = [];
+    pilot.cloudOwnerID = cleanCloudOwnerID(pilot.cloudOwnerID);
+  });
+  _cache = data;
   return data;
 }
 
-export function pilotNames(): Array<{ id: string; name: string }> {
-  return pilotCache;
+export function pilotCache(): CachedCloudPilot[] {
+  return _cache;
 }
 
-export async function fetchPilot(id: string): Promise<PackedPilotData> {
-  if (id.substring(0, 6) != "pilot/") {
-    id = "pilot/" + id;
+export async function fetchPilot(cloudID: string, cloudOwnerID?: string): Promise<PackedPilotData> {
+  // we're just gonna. accept all possible forms of this. let's not fuss.
+  if (!cloudOwnerID && cloudID.includes("//")) { // only one argument, new-style vault id
+    [cloudOwnerID, cloudID] = cloudID.split("//");
+  }
+  if (cloudID.substring(0, 6) != "pilot/") {
+    cloudID = "pilot/" + cloudID;
+  }
+  if (cloudOwnerID && cloudOwnerID.substring(0, 10) != "us-east-1:") {
+    cloudOwnerID = "us-east-1:" + cloudOwnerID;
   }
   try {
     await Auth.currentSession(); // refresh the token if we need to
-  } catch {
+  } catch (e) {
     ui.notifications.error("Sync failed - you aren't logged into a Comp/Con account.");
+    throw e;
   }
-  const res = (await Storage.get(id, { level: "protected", download: true })) as any;
+  const req: any = {
+    level: "protected",
+    download: true
+  };
+  if (cloudOwnerID) { req.identityId = cloudOwnerID; }
+  const res = (await Storage.get(cloudID, req)) as any;
   const text = await res.Body.text();
   return JSON.parse(text);
 }

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -295,7 +295,7 @@ export function replace_default_resource(current: string, replacement: string | 
   }
 
   // If empty or from system path or mystery man, replace
-  if (!current?.trim() || current.includes("system/lancer") || current == "icons/svg/mystery-man.svg") {
+  if (!current?.trim() || current.includes("systems/lancer") || current == "icons/svg/mystery-man.svg") {
     return replacement;
   }
 

--- a/src/module/interfaces.d.ts
+++ b/src/module/interfaces.d.ts
@@ -62,6 +62,13 @@ export type LancerItemSheetData<T extends LancerItemType> = {
   license: License | null;
 };
 
+export type CachedCloudPilot = {
+  id: string,
+  name: string,
+  cloudID: string,
+  cloudOwnerID: string
+}
+
 export type LancerActorSheetData<T extends LancerActorType> = {
   actor: FoundryRegActorData<T>;
   data: LancerActor<T>["data"];
@@ -76,9 +83,10 @@ export type LancerActorSheetData<T extends LancerActorType> = {
   // Store active mech at the root level
   active_mech: Mech | null;
   // Store cloud pilot cache and potential cloud ids at the root level
-  pilotCache: Array<{ id: string, name: string }>;
+  pilotCache: CachedCloudPilot[];
+  cleanedOwnerID: string,
   vaultID: string;
-  gistID: string;
+  rawID: string;
 };
 
 // -------- Macro data -------------------------------------

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -779,8 +779,7 @@ async function rollAttackMacro(actor: Actor, atk_str: string | null, data: Lance
       if (data.overkill) {
         droll.terms.forEach(term => {
           if (term.faces) {
-            term.modifiers.push("x1");
-            term.modifiers.push(`kh1`);
+            term.modifiers = ["x1", `kh${term.number}`].concat(term.modifiers);
           }
         });
       }
@@ -828,8 +827,10 @@ async function rollAttackMacro(actor: Actor, atk_str: string | null, data: Lance
       droll.terms.forEach(term => {
         if (term.faces) {
           term.modifiers === undefined && (term.modifiers = []);
+          if (data.overkill) {
+            term.modifiers = ["x1"].concat(term.modifiers);
+          }
           term.modifiers.push(`kh${term.number}`);
-          data.overkill && term.modifiers.push("x1");
           term.number *= 2;
         }
       });

--- a/src/templates/actor/pilot.hbs
+++ b/src/templates/actor/pilot.hbs
@@ -56,7 +56,7 @@
             {{#select vaultID}}
               <option value="">{{localize "lancer.pilot-sheet.cloud-header.vaultID"}}</option>
               {{#each pilotCache}}
-                <option value="{{id}}">{{name}}</option>
+                <option value="{{cloudOwnerID}}//{{cloudID}}">{{name}}</option>
               {{/each}}
             {{/select}}
           </select>
@@ -64,10 +64,10 @@
             class="lancer-input major"
             style="text-align: center;"
             type="string"
-            name="gistID"
-            value="{{gistID}}"
+            name="rawID"
+            value="{{rawID}}"
             data-dtype="String"
-            placeholder="{{localize "lancer.pilot-sheet.cloud-header.gist-placeholder"}}"
+            placeholder="{{localize "lancer.pilot-sheet.cloud-header.raw-placeholder"}}"
           />
         </div>
 

--- a/src/templates/chat/structure-card.hbs
+++ b/src/templates/chat/structure-card.hbs
@@ -1,5 +1,5 @@
 <div class="card clipped-bot" style="margin: 0px;">
-  <div class="lancer-stat-header clipped-top">{{localize "lancer.chat-card.title" title="STRUCTURE DAMAGE"}}</div>
+  <div class="lancer-stat-header clipped-top">{{localize "lancer.chat-card.title.structure" title="STRUCTURE DAMAGE"}}</div>
   <div style="align-self: center">{{localize "lancer.chat-card.remaining" total=val max=max}}</div>
   {{#if roll}}
     <div class="dice-roll lancer-dice-roll">


### PR DESCRIPTION
#216 (mech/pilot image importing) (~~requires https://github.com/massif-press/lancer-data/pull/153~~ done!)
#252 (overkill) I _think_ is correct now — it always has a `khn` at most, and I _think_ has the explode and kh modifiers happen at the right times in all cases
#256 (can't do negative hp on the token bars) 
#261 (structure damage macro currently borked)