### PR TITLE
Wrap Auth.currentSession() in a try catch block.

### DIFF
--- a/src/module/compcon.ts
+++ b/src/module/compcon.ts
@@ -15,7 +15,12 @@ export function cleanCloudOwnerID(str: string): string {
 export async function populatePilotCache(): Promise<CachedCloudPilot[]> {
   const { Auth } = await import("@aws-amplify/auth");
   const { Storage } = await import("@aws-amplify/storage");
-  await Auth.currentSession(); // refresh the token if we need to
+  try {
+    await Auth.currentSession(); // refresh the token if we need to
+  } catch (e) {
+    console.warn(`AWS Auth failed: ${e}`);
+    return [];
+  }
   const res = await Storage.list("pilot", { level: "protected" });
   const data: Array<PackedPilotData> = await Promise.all(res.map((obj: { key: string }) => fetchPilot(obj.key)));
   data.forEach(pilot => {


### PR DESCRIPTION
In populatePilotCache, the call to Auth.currentSession() fails if there
is no Comp/Con login. This catches the error, logs it as a warning and
returns an empty list instead.
