### PR TITLE
Add a button for deploying a WeaponRangeTemplate to the accdiff dialog

### DIFF
--- a/src/module/item/lancer-item.ts
+++ b/src/module/item/lancer-item.ts
@@ -1,5 +1,14 @@
 import { LANCER, TypeIcon } from "../config";
-import { EntryType, funcs, LiveEntryTypes, OpCtx, RegEntryTypes } from "machine-mind";
+import {
+  EntryType,
+  funcs,
+  LiveEntryTypes,
+  NpcFeatureType,
+  OpCtx,
+  RangeType,
+  RegEntryTypes,
+  RegRangeData,
+} from "machine-mind";
 import { system_ready } from "../../lancer";
 import { mm_wrap_item } from "../mm-util/helpers";
 
@@ -93,6 +102,25 @@ declare global {
 }
 
 export class LancerItem extends Item {
+  /**
+   * Returns all ranges for the item that match the provided range types
+   */
+  rangesFor(types: Set<RangeType> | RangeType[]): RegRangeData[] {
+    const filter = new Set(types);
+    switch (this.data.type) {
+      case EntryType.MECH_WEAPON:
+        const p = this.data.data.selected_profile;
+        return this.data.data.profiles[p].range.filter(r => filter.has(r.type));
+      case EntryType.PILOT_WEAPON:
+        return this.data.data.range.filter(r => filter.has(r.type));
+      case EntryType.NPC_FEATURE:
+        if (this.data.data.type !== NpcFeatureType.Weapon) return [];
+        return this.data.data.range.filter(r => filter.has(r.type));
+      default:
+        return [];
+    }
+  }
+
   /**
    * Force name down to item,
    * And more importantly, perform MM workflow

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -1689,4 +1689,5 @@ export function targetsFromTemplate(templateId: string): void {
     })
     .map(t => t.id);
   game.user!.updateTokenTargets(targets);
+  game.user!.broadcastActivity({ targets });
 }

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -1682,8 +1682,11 @@ export function targetsFromTemplate(templateId: string): void {
   let ignore = canvas.templates!.get(templateId)!.document.getFlag(game.system.id, "ignore");
 
   // Test if each token occupies a targeted space and target it if true
-  canvas.tokens!.placeables.forEach(t => {
-    let skip = ignore.tokens.includes(t.id) || ignore.dispositions.includes(t.data.disposition);
-    t.setTarget(!skip && test_token(<LancerToken>t), { releaseOthers: false, groupSelection: true });
-  });
+  const targets = canvas
+    .tokens!.placeables.filter(t => {
+      let skip = ignore.tokens.includes(t.id) || ignore.dispositions.includes(t.data.disposition);
+      return !skip && test_token(<LancerToken>t);
+    })
+    .map(t => t.id);
+  game.user!.updateTokenTargets(targets);
 }

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -62,7 +62,7 @@ export async function runEncodedMacro(el: HTMLElement | LancerMacroData) {
   let data: LancerMacroData | null = null;
 
   if (el instanceof HTMLElement) {
-    let encoded = el.attributes.getNamedItem('data-macro')?.nodeValue;
+    let encoded = el.attributes.getNamedItem("data-macro")?.nodeValue;
     if (!encoded) {
       console.warn("No macro data available");
       return;
@@ -79,7 +79,7 @@ export async function runEncodedMacro(el: HTMLElement | LancerMacroData) {
   }
 
   let fn = (game as LancerGame).lancer[data.fn];
-  return (fn as any).apply(null, data.args)
+  return (fn as any).apply(null, data.args);
 }
 
 export async function onHotbarDrop(_bar: any, data: any, slot: number) {
@@ -91,7 +91,8 @@ export async function onHotbarDrop(_bar: any, data: any, slot: number) {
   let img = `systems/${game.system.id}/assets/icons/macro-icons/d20-framed.svg`;
 
   // Grab new encoded data ASAP
-  if (data.fn && data.args && data.title) { // i.e., data instanceof LancerMacroData
+  if (data.fn && data.args && data.title) {
+    // i.e., data instanceof LancerMacroData
     if (encodedMacroWhitelist.indexOf(data.fn) < 0) {
       ui.notifications!.error("You are trying to drop an invalid macro");
       return;
@@ -250,10 +251,7 @@ function ownedItemFromString(i: string, actor: LancerActor): LancerItem | null {
 export async function prepareItemMacro(a: string, i: string, options?: any) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   const item = ownedItemFromString(i, actor);
 
@@ -349,6 +347,10 @@ export async function prepareItemMacro(a: string, i: string, options?: any) {
   applyCollapseListeners();
 }
 
+/**
+ * Get an actor to use for a macro. If an id is passed and the return is
+ * `undefined` a warning notification will be displayed.
+ */
 export function getMacroSpeaker(a_id?: string): LancerActor | undefined {
   // Determine which Actor to speak as
   const speaker = ChatMessage.getSpeaker();
@@ -371,7 +373,7 @@ export function getMacroSpeaker(a_id?: string): LancerActor | undefined {
   if (!actor || (a_id && actor.id !== a_id)) {
     actor = game.actors!.tokens[a_id!];
   }
-  if (!actor) {
+  if (!actor && a_id !== undefined) {
     ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
   }
   return actor;
@@ -449,10 +451,7 @@ function getMacroActorItem(a: string, i: string): { actor: LancerActor | undefin
   let result: { actor: LancerActor | undefined; item: LancerItem | undefined } = { actor: undefined, item: undefined };
   // Find the Actor for a macro to speak as
   result.actor = getMacroSpeaker(a);
-  if (!result.actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return result;
-  }
+  if (!result.actor) return result;
 
   // Find the item
   result.item = result.actor.items.get(i);
@@ -479,13 +478,13 @@ function applyPluginsToRoll(str: string, plugins: { modifyRoll(i: string): strin
 }
 
 type AttackRolls = {
-  roll: string,
+  roll: string;
   targeted: {
-    target: Token,
-    roll: string,
-    usedLockOn: { delete: () => void } | null,
-  }[]
-}
+    target: Token;
+    roll: string;
+    usedLockOn: { delete: () => void } | null;
+  }[];
+};
 
 function attackRolls(bonus: number, accdiff: AccDiffData): AttackRolls {
   let perRoll = Object.values(accdiff.weapon.plugins);
@@ -498,8 +497,8 @@ function attackRolls(bonus: number, accdiff: AccDiffData): AttackRolls {
         target: tad.target,
         roll: applyPluginsToRoll(rollStr(bonus, tad.total), perTarget),
         usedLockOn: tad.usingLockOn,
-      }
-    })
+      };
+    }),
   };
 }
 
@@ -522,9 +521,14 @@ export async function prepareStatMacro(a: string, statKey: string, rerollData?: 
     let partialMacroData = {
       title: "Reroll stat macro",
       fn: "prepareStatMacro",
-      args: [a, statKey]
+      args: [a, statKey],
     };
-    rollTechMacro(actor, { acc: 0, action: "Quick", t_atk: bonus, effect: "", tags: [], title: "" }, partialMacroData, rerollData);
+    rollTechMacro(
+      actor,
+      { acc: 0, action: "Quick", t_atk: bonus, effect: "", tags: [], title: "" },
+      partialMacroData,
+      rerollData
+    );
   } else {
     rollStatMacro(actor, mData).then();
   }
@@ -540,13 +544,13 @@ async function rollStatMacro(actor: LancerActor, data: LancerStatMacroData) {
   if (!actor) return Promise.resolve();
 
   // Get accuracy/difficulty with a prompt
-  let { AccDiffData } = await import('./helpers/acc_diff');
+  let { AccDiffData } = await import("./helpers/acc_diff");
   let initialData = AccDiffData.fromParams(actor, undefined, data.title);
 
   let promptedData;
   try {
-    let { open } = await import('./helpers/slidinghud');
-    promptedData = await open('hase', initialData);
+    let { open } = await import("./helpers/slidinghud");
+    promptedData = await open("hase", initialData);
   } catch (_e) {
     return;
   }
@@ -594,16 +598,20 @@ async function rollTalentMacro(actor: LancerActor, data: LancerTalentMacroData) 
 type AttackMacroOptions = {
   accBonus: number;
   damBonus: { type: DamageType; val: number };
-}
+};
 
 export async function prepareEncodedAttackMacro(
-  actor_ref: RegRef<any>, item_id: string | null, options: AttackMacroOptions, rerollData: AccDiffDataSerialized) {
+  actor_ref: RegRef<any>,
+  item_id: string | null,
+  options: AttackMacroOptions,
+  rerollData: AccDiffDataSerialized
+) {
   let reg = new FoundryReg();
-  let opCtx = new OpCtx()
+  let opCtx = new OpCtx();
   let mm = await reg.resolve(opCtx, actor_ref);
   let actor = mm.Flags.orig_doc;
   let item = item_id ? ownedItemFromString(item_id, actor) : null;
-  let { AccDiffData } = await import('./helpers/acc_diff');
+  let { AccDiffData } = await import("./helpers/acc_diff");
   let accdiff = AccDiffData.fromObject(rerollData, item ?? actor);
   if (item) {
     return prepareAttackMacro({ actor, item, options }, accdiff);
@@ -622,18 +630,21 @@ export async function prepareEncodedAttackMacro(
  *                              The "Bonus" type is recommended but not required
  * @param rerollData {AccDiffData?} saved accdiff data for rerolls
  */
-async function prepareAttackMacro({
-  actor,
-  item,
-  options,
-}: {
-  actor: LancerActor;
-  item: LancerItem;
-  options?: {
-    accBonus: number;
-    damBonus: { type: DamageType; val: number };
-  };
-}, rerollData?: AccDiffData) {
+async function prepareAttackMacro(
+  {
+    actor,
+    item,
+    options,
+  }: {
+    actor: LancerActor;
+    item: LancerItem;
+    options?: {
+      accBonus: number;
+      damBonus: { type: DamageType; val: number };
+    };
+  },
+  rerollData?: AccDiffData
+) {
   if (!item.is_npc_feature() && !item.is_mech_weapon() && !item.is_pilot_weapon()) return;
   let mData: LancerAttackMacroData = {
     title: item.name ?? "",
@@ -760,14 +771,15 @@ async function prepareAttackMacro({
 
   // Prompt the user before deducting charges.
   const targets = Array.from(game!.user!.targets);
-  let { AccDiffData } = await import('./helpers/acc_diff');
-  const initialData = rerollData ?? AccDiffData.fromParams(
-    item, mData.tags, mData.title, targets, mData.acc > 0 ? [mData.acc, 0] : [0, -mData.acc]);
+  let { AccDiffData } = await import("./helpers/acc_diff");
+  const initialData =
+    rerollData ??
+    AccDiffData.fromParams(item, mData.tags, mData.title, targets, mData.acc > 0 ? [mData.acc, 0] : [0, -mData.acc]);
 
   let promptedData;
   try {
-    let { open } = await import('./helpers/slidinghud');
-    promptedData = await open('attack', initialData);
+    let { open } = await import("./helpers/slidinghud");
+    promptedData = await open("attack", initialData);
   } catch (_e) {
     return;
   }
@@ -791,12 +803,7 @@ async function prepareAttackMacro({
   let rerollMacro = {
     title: "Reroll attack",
     fn: "prepareEncodedAttackMacro",
-    args: [
-      actor.data.data.derived.mm!.as_ref(),
-      item.id,
-      options,
-      promptedData.toObject()
-    ]
+    args: [actor.data.data.derived.mm!.as_ref(), item.id, options, promptedData.toObject()],
   };
 
   await rollAttackMacro(actor, atkRolls, mData, rerollMacro);
@@ -833,22 +840,21 @@ export async function openBasicAttack(rerollData?: AccDiffData) {
   }
 
   let mData = {
-    title: 'BASIC ATTACK',
+    title: "BASIC ATTACK",
     grit: 0,
     acc: 0,
     tags: [],
     damage: [],
   };
 
-
   let pilotEnt: Pilot;
-  if (actor.data.type === EntryType.MECH) {
+  if (actor.is_mech()) {
     pilotEnt = (await actor.data.data.derived.mm_promise).Pilot!;
     mData.grit = pilotEnt.Grit;
-  } else if (actor.data.type === EntryType.PILOT) {
+  } else if (actor.is_pilot()) {
     pilotEnt = await actor.data.data.derived.mm_promise;
     mData.grit = pilotEnt.Grit;
-  } else if (actor.data.type === EntryType.NPC) {
+  } else if (actor.is_npc()) {
     const mm = await actor.data.data.derived.mm_promise;
     let tier_bonus: number = mm.Tier - 1;
     mData.grit = tier_bonus || 0;
@@ -862,70 +868,75 @@ export async function openBasicAttack(rerollData?: AccDiffData) {
   let rerollMacro = {
     title: "Reroll attack",
     fn: "prepareEncodedAttackMacro",
-    args: [
-      actor.data.data.derived.mm!.as_ref(),
-      null,
-      {},
-      promptedData.toObject()
-    ]
+    args: [actor.data.data.derived.mm!.as_ref(), null, {}, promptedData.toObject()],
   };
 
   await rollAttackMacro(actor, atkRolls, mData, rerollMacro);
 }
 
 type AttackResult = {
-  roll: Roll,
-  tt: string | HTMLElement | JQuery<HTMLElement>
-}
+  roll: Roll;
+  tt: string | HTMLElement | JQuery<HTMLElement>;
+};
 
 type HitResult = {
-  token: { name: string, img: string },
-  total: string,
-  hit: boolean,
-  crit: boolean
-}
+  token: { name: string; img: string };
+  total: string;
+  hit: boolean;
+  crit: boolean;
+};
 
-async function checkTargets(atkRolls: AttackRolls, isSmart: boolean): Promise<{
-  attacks: AttackResult[],
-  hits: HitResult[]
+async function checkTargets(
+  atkRolls: AttackRolls,
+  isSmart: boolean
+): Promise<{
+  attacks: AttackResult[];
+  hits: HitResult[];
 }> {
   if (game.settings.get(game.system.id, LANCER.setting_automation_attack) && atkRolls.targeted.length > 0) {
-    let data = await Promise.all(atkRolls.targeted.map(async targetingData => {
-      let target = targetingData.target;
-      let actor = target.actor as LancerActor;
-      let attack_roll = await new Roll(targetingData.roll).evaluate({ async: true });
-      const attack_tt = await attack_roll.getTooltip();
+    let data = await Promise.all(
+      atkRolls.targeted.map(async targetingData => {
+        let target = targetingData.target;
+        let actor = target.actor as LancerActor;
+        let attack_roll = await new Roll(targetingData.roll).evaluate({ async: true });
+        const attack_tt = await attack_roll.getTooltip();
 
-      if (targetingData.usedLockOn) {
-        targetingData.usedLockOn.delete();
-      }
-
-      return {
-        attack: { roll: attack_roll, tt: attack_tt },
-        hit: {
-          token: { name: target.data.name!, img: target.data.img! },
-          total: String(attack_roll.total).padStart(2, "0"),
-          hit: await checkForHit(isSmart, attack_roll, actor),
-          crit: (attack_roll.total || 0) >= 20,
+        if (targetingData.usedLockOn) {
+          targetingData.usedLockOn.delete();
         }
-      }
-    }));
+
+        return {
+          attack: { roll: attack_roll, tt: attack_tt },
+          hit: {
+            token: { name: target.data.name!, img: target.data.img! },
+            total: String(attack_roll.total).padStart(2, "0"),
+            hit: await checkForHit(isSmart, attack_roll, actor),
+            crit: (attack_roll.total || 0) >= 20,
+          },
+        };
+      })
+    );
 
     return {
       attacks: data.map(d => d.attack),
-      hits: data.map(d => d.hit)
+      hits: data.map(d => d.hit),
     };
   } else {
     let attack_roll = await new Roll(atkRolls.roll).evaluate({ async: true });
     const attack_tt = await attack_roll.getTooltip();
     return {
       attacks: [{ roll: attack_roll, tt: attack_tt }],
-      hits: []
-    }
+      hits: [],
+    };
   }
 }
 
-async function rollAttackMacro(actor: LancerActor, atkRolls: AttackRolls, data: LancerAttackMacroData, rerollMacro: LancerMacroData) {
+async function rollAttackMacro(
+  actor: LancerActor,
+  atkRolls: AttackRolls,
+  data: LancerAttackMacroData,
+  rerollMacro: LancerMacroData
+) {
   const isSmart = data.tags.findIndex(tag => tag.Tag.LID === "tg_smart") > -1;
   const { attacks, hits } = await checkTargets(atkRolls, isSmart);
 
@@ -1062,7 +1073,7 @@ async function rollAttackMacro(actor: LancerActor, atkRolls: AttackRolls, data: 
     effect: data.effect ? data.effect : null,
     on_hit: data.on_hit ? data.on_hit : null,
     tags: data.tags,
-    rerollMacroData: encodeMacroData(rerollMacro)
+    rerollMacroData: encodeMacroData(rerollMacro),
   };
 
   console.debug(templateData);
@@ -1244,13 +1255,19 @@ export async function prepareTechMacro(a: string, t: string, rerollData?: AccDif
   let partialMacroData = {
     title: "Reroll tech attack",
     fn: "prepareTechMacro",
-    args: [a, t]
-  }
+    args: [a, t],
+  };
 
   await rollTechMacro(actor, mData, partialMacroData, rerollData, item);
 }
 
-async function rollTechMacro(actor: LancerActor, data: LancerTechMacroData, partialMacroData: LancerMacroData, rerollData?: AccDiffDataSerialized, item?: LancerItem) {
+async function rollTechMacro(
+  actor: LancerActor,
+  data: LancerTechMacroData,
+  partialMacroData: LancerMacroData,
+  rerollData?: AccDiffDataSerialized,
+  item?: LancerItem
+) {
   const targets = Array.from(game!.user!.targets);
   let { AccDiffData } = await import('./helpers/acc_diff');
   const initialData = rerollData ?
@@ -1259,8 +1276,8 @@ async function rollTechMacro(actor: LancerActor, data: LancerTechMacroData, part
 
   let promptedData;
   try {
-    let { open } = await import('./helpers/slidinghud');
-    promptedData = await open('attack', initialData);
+    let { open } = await import("./helpers/slidinghud");
+    promptedData = await open("attack", initialData);
   } catch (_e) {
     return;
   }
@@ -1290,22 +1307,19 @@ async function rollTechMacro(actor: LancerActor, data: LancerTechMacroData, part
 export async function prepareOverchargeMacro(a: string) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   // Validate that we're overcharging a mech
   if (!actor.is_mech()) {
     ui.notifications!.warn(`Only mechs can overcharge!`);
-    return null;
+    return;
   }
 
   // And here too... we should probably revisit our type definitions...
   let rollText = actor.getOverchargeRoll();
   if (!rollText) {
     ui.notifications!.warn(`Error in getting overcharge roll...`);
-    return null;
+    return;
   }
 
   // Prep data
@@ -1352,10 +1366,13 @@ async function rollOverchargeMacro(actor: LancerActor, data: LancerOverchargeMac
 
 export function prepareStructureSecondaryRollMacro(registryId: string) {
   // @ts-ignore
-  let roll = new Roll('1d6').evaluate({ async: false });
+  let roll = new Roll("1d6").evaluate({ async: false });
   let result = roll.total!;
   if (result <= 3) {
-    prepareTextMacro(registryId, "Destroy Weapons", `
+    prepareTextMacro(
+      registryId,
+      "Destroy Weapons",
+      `
 <div class="dice-roll lancer-dice-roll">
   <div class="dice-result">
     <div class="dice-formula lancer-dice-formula flexrow">
@@ -1364,9 +1381,13 @@ export function prepareStructureSecondaryRollMacro(registryId: string) {
     </div>
   </div>
 </div>
-<span>On a 1–3, all weapons on one mount of your choice are destroyed</span>`);
+<span>On a 1–3, all weapons on one mount of your choice are destroyed</span>`
+    );
   } else {
-    prepareTextMacro(registryId, "Destroy Systems", `
+    prepareTextMacro(
+      registryId,
+      "Destroy Systems",
+      `
 <div class="dice-roll lancer-dice-roll">
   <div class="dice-result">
     <div class="dice-formula lancer-dice-formula flexrow">
@@ -1375,7 +1396,8 @@ export function prepareStructureSecondaryRollMacro(registryId: string) {
     </div>
   </div>
 </div>
-<span>On a 4–6, a system of your choice is destroyed</span>`);
+<span>On a 4–6, a system of your choice is destroyed</span>`
+    );
   }
 }
 
@@ -1425,10 +1447,7 @@ export async function prepareChargeMacro(a: string) {
 export async function prepareOverheatMacro(a: string) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   // Hand it off to the actor to overheat
   await actor.overheat();
@@ -1442,16 +1461,19 @@ export async function prepareStructureMacro(a: string) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
 
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   // Hand it off to the actor to structure
   await actor.structure();
 }
 
-export async function prepareActivationMacro(a: string, i: string, type: ActivationOptions, index: number, rerollData?: AccDiffDataSerialized) {
+export async function prepareActivationMacro(
+  a: string,
+  i: string,
+  type: ActivationOptions,
+  index: number,
+  rerollData?: AccDiffDataSerialized
+) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
   if (!actor) return;
@@ -1483,7 +1505,7 @@ export async function prepareActivationMacro(a: string, i: string, type: Activat
           let partialMacroData = {
             title: "Reroll activation",
             fn: "prepareActivationMacro",
-            args: [a, i, type, index]
+            args: [a, i, type, index],
           };
           _prepareTechActionMacro(actorEnt, itemEnt, index, partialMacroData, rerollData);
           break;
@@ -1508,7 +1530,13 @@ async function _prepareTextActionMacro(actorEnt: Mech, itemEnt: MechSystem | Npc
   await renderMacroHTML(actorEnt.Flags.orig_doc, buildActionHTML(action, { full: true, tags: itemEnt.Tags }));
 }
 
-async function _prepareTechActionMacro(actorEnt: Mech, itemEnt: MechSystem | NpcFeature, index: number, partialMacroData: LancerMacroData, rerollData?: AccDiffDataSerialized) {
+async function _prepareTechActionMacro(
+  actorEnt: Mech,
+  itemEnt: MechSystem | NpcFeature,
+  index: number,
+  partialMacroData: LancerMacroData,
+  rerollData?: AccDiffDataSerialized
+) {
   // Support this later...
   if (itemEnt.Type !== EntryType.MECH_SYSTEM) return;
 
@@ -1557,10 +1585,7 @@ async function _prepareDeployableMacro(actorEnt: Mech, itemEnt: MechSystem | Npc
 export async function fullRepairMacro(a: string) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   return new Promise<number>((_resolve, reject) => {
     new Dialog({
@@ -1596,10 +1621,7 @@ export async function fullRepairMacro(a: string) {
 export async function stabilizeMacro(a: string) {
   // Determine which Actor to speak as
   let actor = getMacroSpeaker(a);
-  if (!actor) {
-    ui.notifications!.warn(`Failed to find Actor for macro. Do you need to select a token?`);
-    return null;
-  }
+  if (!actor) return;
 
   let template = await renderTemplate(`systems/${game.system.id}/templates/window/promptStabilize.hbs`, {});
 

--- a/src/module/pixi/weapon-range-template.ts
+++ b/src/module/pixi/weapon-range-template.ts
@@ -31,14 +31,20 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
     return this.range.type === RangeType.Burst;
   }
 
+  private actorSheet: FormApplication | undefined;
+
   /**
    * Creates a new WeaponRangeTemplate from a provided range object
-   * @param type - Type of template
-   * @param val  - Size of template
+   * @param type - Type of template. A RangeType in typescript, or a string in js.
+   * @param val  - Size of template. A numeric string
+   * @param creator - A token that is designated as the owner of the template.
+   *                  Used to deterimine the character sheet to close as well
+   *                  as a default ignore target for Cones and Lines.
    */
   static fromRange({ type, val }: WeaponRangeTemplate["range"], creator?: Token): WeaponRangeTemplate | null {
     if (!canvas.ready) return null;
     let dist = parseInt(val);
+    if (isNaN(dist)) return null;
     let hex: boolean = (canvas.grid?.type ?? 0) >= 2;
 
     let shape: "cone" | "ray" | "circle";
@@ -73,7 +79,7 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
           range: { type, val },
           creator: creator?.id,
           ignore: {
-            tokens: type === RangeType.Blast || !creator ? [] : [creator.id],
+            tokens: [RangeType.Blast, RangeType.Burst].includes(type) || !creator ? [] : [creator.id],
             dispositions: <TokenDocument["data"]["disposition"][]>[],
           },
         },
@@ -83,6 +89,7 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
     const cls = CONFIG.MeasuredTemplate.documentClass;
     const template = new cls(templateData, { parent: canvas.scene ?? undefined });
     const object = new this(template);
+    object.actorSheet = creator?.actor?.sheet ?? undefined;
     return object;
   }
 
@@ -106,6 +113,7 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
       ui.notifications?.error("Cannot create WeaponRangeTemplate. Canvas is not ready");
       throw new Error("Cannot create WeaponRangeTemplate. Canvas is not ready");
     }
+    this.actorSheet?.minimize();
     const initialLayer = canvas.activeLayer;
     this.draw();
     this.layer.activate();
@@ -113,7 +121,9 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
     return this.activatePreviewListeners(initialLayer);
   }
 
-  private activatePreviewListeners(initialLayer: CanvasLayer<CanvasLayerOptions> | null): Promise<MeasuredTemplateDocument> {
+  private activatePreviewListeners(
+    initialLayer: CanvasLayer<CanvasLayerOptions> | null
+  ): Promise<MeasuredTemplateDocument> {
     return new Promise<MeasuredTemplateDocument>((resolve, reject) => {
       const handlers: any = {};
       let moveTime = 0;
@@ -135,6 +145,7 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
 
       // Cancel the workflow (right-click)
       handlers.rc = (_e: unknown, do_reject: boolean = true) => {
+        this.actorSheet?.maximize();
         // Remove the preview
         this.layer.preview?.removeChildren().forEach(c => c.destroy());
         canvas.stage?.off("mousemove", handlers.mm);

--- a/src/module/pixi/weapon-range-template.ts
+++ b/src/module/pixi/weapon-range-template.ts
@@ -43,9 +43,10 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
    */
   static fromRange({ type, val }: WeaponRangeTemplate["range"], creator?: Token): WeaponRangeTemplate | null {
     if (!canvas.ready) return null;
-    let dist = parseInt(val);
+    const dist = parseInt(val);
     if (isNaN(dist)) return null;
-    let hex: boolean = (canvas.grid?.type ?? 0) >= 2;
+    const hex: boolean = (canvas.grid?.type ?? 0) >= 2;
+    const grid_distance = (canvas.scene?.dimensions as Partial<Canvas.Dimensions> | undefined)?.distance ?? 1;
 
     let shape: "cone" | "ray" | "circle";
     switch (type) {
@@ -67,8 +68,8 @@ export class WeaponRangeTemplate extends MeasuredTemplate {
     const templateData = {
       t: shape,
       user: game.user!.id,
-      distance: (dist + 0.1) * scale,
-      width: scale,
+      distance: (dist + 0.1) * scale * grid_distance,
+      width: scale * grid_distance,
       direction: 0,
       x: 0,
       y: 0,


### PR DESCRIPTION
The button only shows for weapons that have a range listed that is an
AoE range (such as Burst 3) and clicking it fades the HUD out until
placement is either completed or cancelled. Upon placement, units that
are within the highlighted area of the MeasuredTemplate are set as the
user's targets and the dialog refreshes with the new targets.

 - [x] Targeting algorithm is very naïve and brute force.
 - [x] Targeting algorithm bypasses broadcasting targets.
 - [x] Scale with grid units. Just in case.™
 - [x] #302 Merged