### PR TITLE
Use a store for game.user.targets for svelte components

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "",
   "devDependencies": {
     "@league-of-foundry-developers/foundry-vtt-types": "^0.8.9-2",
-    "@pyoner/svelte-types": "^3.4.4-2",
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.15",
     "@tsconfig/svelte": "^2.0.1",
     "archiver": "^3.1.1",

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -481,13 +481,16 @@ Hooks.once("init", async function () {
   // ------------------------------------------------------------------------
   // Sliding HUD Zone, including accuracy/difficulty window
   Hooks.on('renderHeadsUpDisplay', slidingHUD.attach);
-  Hooks.on('targetToken', (_user: User, _token: Token, isNewTarget: boolean) => {
-    macros.refreshTargeting(isNewTarget ? "may open new window" : "only refresh open window");
+  let openingBasicAttackLock = false;
+  Hooks.on('targetToken', (user: User, _token: Token, isNewTarget: boolean) => {
+    if (game.user == user && isNewTarget && !openingBasicAttackLock) {
+      // this only works because openBasicAttack is a promise and runs on a future tick
+      openingBasicAttackLock = true;
+      macros.openBasicAttack().finally(() => {
+        openingBasicAttackLock = false;
+      });
+    }
   });
-  Hooks.on('createActiveEffect', () => macros.refreshTargeting("only refresh open window"));
-  Hooks.on('deleteActiveEffect', () => macros.refreshTargeting("only refresh open window"));
-  // updateToken triggers on things like token movement (spotter) and probably a lot of other things
-  Hooks.on('updateToken', () => macros.refreshTargeting("only refresh open window"));
 });
 
 // TODO: either remove when sanity check is no longer needed, or find a better home.

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -483,7 +483,7 @@ Hooks.once("init", async function () {
   Hooks.on('renderHeadsUpDisplay', slidingHUD.attach);
   let openingBasicAttackLock = false;
   Hooks.on('targetToken', (user: User, _token: Token, isNewTarget: boolean) => {
-    if (game.user == user && isNewTarget && !openingBasicAttackLock) {
+    if (user.isSelf && isNewTarget && !openingBasicAttackLock) {
       // this only works because openBasicAttack is a promise and runs on a future tick
       openingBasicAttackLock = true;
       macros.openBasicAttack().finally(() => {

--- a/src/module/helpers/slidinghud/SlidingHUDZone.svelte
+++ b/src/module/helpers/slidinghud/SlidingHUDZone.svelte
@@ -9,6 +9,7 @@
 
  import { sidebarWidth } from './sidebar-width';
  import { isDragging } from './is-dragging';
+ import { userTargets } from './user-targets';
  import AccDiffForm from '../acc_diff/Form.svelte';
 
  let dispatch = createEventDispatcher();
@@ -28,6 +29,15 @@
    hase: { open: null },
    attack: { open: null }
  };
+
+ // this indirection means that only actual changes to huds.attack.data trigger the following update
+ $: attackData = huds.attack.data;
+ $: {
+   if (attackData) {
+     attackData.replaceTargets($userTargets);
+     attackData = attackData;
+   }
+ }
 
  export function open(key: string, data: any) {
    dispatch(`${key}.cancel`);

--- a/src/module/helpers/slidinghud/index.ts
+++ b/src/module/helpers/slidinghud/index.ts
@@ -1,7 +1,7 @@
 import type HUDZone from './SlidingHUDZone.svelte';
 import type { AccDiffData } from '../acc_diff';
 
-let hud: typeof HUDZone;
+let hud: HUDZone;
 
 export async function attach() {
   if (!hud) {
@@ -17,7 +17,6 @@ export async function open(key: "hase" | "attack", data: AccDiffData): Promise<A
   let hud = await attach();
 
   // open the hud, cancelling existing listeners
-  // @ts-ignore
   hud.open(key, data);
 
   return new Promise((resolve, reject) => {
@@ -28,12 +27,10 @@ export async function open(key: "hase" | "attack", data: AccDiffData): Promise<A
 
 export async function isOpen(key: "hase" | "attack"): Promise<boolean> {
   let hud = await attach();
-  // @ts-ignore
   return hud.isOpen(key);
 }
 
 export async function fade(dir: "out" | "in" = "out") {
   let hud = await attach();
-  // @ts-ignore
   hud.fade(dir);
 }

--- a/src/module/helpers/slidinghud/index.ts
+++ b/src/module/helpers/slidinghud/index.ts
@@ -1,6 +1,5 @@
 import type HUDZone from './SlidingHUDZone.svelte';
 import type { AccDiffData } from '../acc_diff';
-import type { LancerActor } from '../../actor/lancer-actor';
 
 let hud: typeof HUDZone;
 
@@ -27,48 +26,10 @@ export async function open(key: "hase" | "attack", data: AccDiffData): Promise<A
   });
 }
 
-// this method differs from open() in two key ways
-// 1. it's not allowed to open new windows
-// 2. it never allows the caller to observe the data via promise,
-//      assuming if the window was open that the existing handler is what we want to preserve
-export async function refreshTargets(key: "hase" | "attack", ts: Token[] | AccDiffData) {
-  let hud = await attach();
-
-  // this method isn't allowed to open new windows, so bail out if it isn't open
-  // @ts-ignore
-  if (!hud.isOpen(key)) { return; }
-
-  let { AccDiffData } = await import('../acc_diff');
-
-  if (ts instanceof AccDiffData) {
-    // @ts-ignore
-    return hud.refresh(key, ts);
-  }
-
-  // @ts-ignore
-  let oldData: AccDiffData = hud.data(key);
-  if (!oldData || !(oldData instanceof AccDiffData)) {
-    throw new Error(`${key} hud is open without valid data: ${oldData}`);
-  }
-  let data: AccDiffData = oldData.replaceTargets(ts);
-
-  // @ts-ignore
-  hud.refresh(key, data);
-}
-
-// this method opens a new window if one isn't open, with as much data as we have, allowing new listeners
-// otherwise, it refreshes the existing window, disallowing new listeners
-export async function openOrRefresh(key: "hase" | "attack", ts: Token[] | AccDiffData, title: string, actor?: LancerActor,): Promise<AccDiffData> {
+export async function isOpen(key: "hase" | "attack"): Promise<boolean> {
   let hud = await attach();
   // @ts-ignore
-  if (hud.isOpen(key)) {
-    refreshTargets(key, ts);
-    return new Promise((_res, rej) => rej());
-  } else {
-    let { AccDiffData } = await import('../acc_diff');
-    return open(key, ts instanceof AccDiffData ? ts :
-      AccDiffData.fromParams(actor, undefined, title, ts, undefined))
-  }
+  return hud.isOpen(key);
 }
 
 export async function fade(dir: "out" | "in" = "out") {

--- a/src/module/helpers/slidinghud/user-targets.ts
+++ b/src/module/helpers/slidinghud/user-targets.ts
@@ -6,7 +6,7 @@ export const userTargets = readable([] as Token[], update => {
   }
 
   Hooks.on('targetToken', (user: User, _token: Token, _isNewTarget: boolean) => {
-    if (user == game.user) {
+    if (user.isSelf) {
       updateData();
     }
   })

--- a/src/module/helpers/slidinghud/user-targets.ts
+++ b/src/module/helpers/slidinghud/user-targets.ts
@@ -1,0 +1,17 @@
+import { readable } from "svelte/store";
+
+export const userTargets = readable([] as Token[], update => {
+  function updateData() {
+    update(Array.from(game!.user!.targets));
+  }
+
+  Hooks.on('targetToken', (user: User, _token: Token, _isNewTarget: boolean) => {
+    if (user == game.user) {
+      updateData();
+    }
+  })
+  Hooks.on('createActiveEffect', updateData);
+  Hooks.on('deleteActiveEffect', updateData);
+  // updateToken triggers on things like token movement (spotter) and probably a lot of other things
+  Hooks.on('updateToken', updateData);
+});

--- a/src/module/helpers/svelte-application.ts
+++ b/src/module/helpers/svelte-application.ts
@@ -7,7 +7,7 @@ type SvelteAppOptions = Application.Options & {
 export default class SvelteApp<DataModel> extends Application {
   klass: typeof SvelteComponent;
   data: DataModel;
-  component?: typeof SvelteComponent; // the type reuses the same type for class and instance
+  component?: SvelteComponent;
   declare options: SvelteAppOptions;
 
   #resolve: ((data: DataModel) => void) | null = null;

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -608,7 +608,7 @@ export async function prepareEncodedAttackMacro(
   if (item) {
     return prepareAttackMacro({ actor, item, options }, accdiff);
   } else {
-    return refreshTargeting("may open new window", accdiff);
+    return openBasicAttack(accdiff);
   }
 }
 
@@ -802,22 +802,26 @@ async function prepareAttackMacro({
   await rollAttackMacro(actor, atkRolls, mData, rerollMacro);
 }
 
-export async function refreshTargeting(
-  mode: "may open new window" | "only refresh open window",
-  data: Token[] | AccDiffData = Array.from(game!.user!.targets)
-) {
-  let { refreshTargets, openOrRefresh } = await import('./helpers/slidinghud');
+export async function openBasicAttack(rerollData?: AccDiffData) {
+  let { isOpen, open } = await import('./helpers/slidinghud');
 
-  if (mode == "only refresh open window") {
-    refreshTargets("attack", data);
+  // if the hud is already open, and we're not overriding with new reroll data, just bail out
+  let wasOpen = await isOpen("attack");
+  if (wasOpen && !rerollData) {
     return;
   }
 
+  let { AccDiffData } = await import("./helpers/acc_diff");
+
   let actor = getMacroSpeaker();
+
+  let data = rerollData ?? AccDiffData.fromParams(
+    actor, undefined, "Basic Attack",
+    Array.from(game!.user!.targets), undefined);
 
   let promptedData;
   try {
-    promptedData = await openOrRefresh("attack", data, "Basic Attack", actor);
+    promptedData = await open("attack", data);
   } catch (_e) {
     return;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     ],
     "types": [
       "@league-of-foundry-developers/foundry-vtt-types",
-      "@pyoner/svelte-types"
+      "svelte"
     ],
     "moduleResolution": "node",
     "strictNullChecks": true,


### PR DESCRIPTION
Due to bindings, we still trigger updates exactly twice per outside update, but I think? they're within the same synchronous stackframe, so it's fine. It's fine. It's totally fine. It's fine! 

Tests appreciated in all the weird and wonderful cases yall have found :)

Also, handles the case where you had stuff targeted and someone else targeted something, because that shouldn't open a new dialog.