### PR TITLE
Set prototype token size based on unit size.

### DIFF
--- a/src/module/token.ts
+++ b/src/module/token.ts
@@ -107,3 +107,22 @@ export function fix_modify_token_attribute(data: any) {
     }
   }
 }
+
+declare global {
+  interface FlagConfig {
+    Token: {
+      [game.system.id]?: {
+        mm_size?: number | undefined;
+      }
+      "hex-size-support"?: {
+        borderSize?: number;
+        altSnapping?: boolean;
+        evenSnap?: boolean;
+        alwaysShowBorder?: boolean;
+        alternateOrientation?: boolean;
+        pivotx?: number;
+        pivoty?: number;
+      };
+    }
+  }
+}


### PR DESCRIPTION
Automatically sets the size of prototype tokens to match the size of the
actor, as computed by machine-mind. Manual changes will be persisted
until the mm computed size changes. Manually changing the size of the
Frame, NpcClass or Deployable will immediately change the prototype as
will swapping Class or Frame.

Additionally sets imported mechs to the same disposition as their pilot
and deployables to neutral, as well as setting actorLink for mechs.

Fixes #301 
Fixes #122 
