### PR TITLE
Reuse existing roll for critical hits

### DIFF
--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -5,6 +5,7 @@ import { simple_mm_ref } from "./refs";
 import { encodeMacroData } from "../macros";
 import type { ActionType } from "../action";
 import { LANCER } from "../config";
+import type { LancerActor } from "../actor/lancer-actor";
 // ---------------------------------------
 // Some simple stat editing thingies
 
@@ -52,8 +53,8 @@ export function stat_view_card(
   let data_val = resolve_helper_dotpath(options, data_path);
   let macro_button: string | undefined;
   // Determine whether this is an unlinked token, so we can encode the correct id for the macro.
-  const r_actor = options.data.root.actor;
-  let id = r_actor.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor.actor.id!;
+  const r_actor = options.data.root.actor as LancerActor;
+  let id = r_actor.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor.id!;
   console.log(r_actor, id);
   let macroData = encodeMacroData({
     title: title,

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -53,8 +53,8 @@ export function stat_view_card(
   let data_val = resolve_helper_dotpath(options, data_path);
   let macro_button: string | undefined;
   // Determine whether this is an unlinked token, so we can encode the correct id for the macro.
-  const r_actor = options.data.root.actor as LancerActor;
-  let id = r_actor.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor.id!;
+  const r_actor = options.data.root.actor as LancerActor | undefined;
+  let id = r_actor?.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor?.id!;
   console.log(r_actor, id);
   let macroData = encodeMacroData({
     title: title,
@@ -131,8 +131,8 @@ export function clicker_stat_card(
 ): string {
   let button = "";
   // Determine whether this is an unlinked token, so we can encode the correct id for the macro.
-  const r_actor = options.data.root.actor;
-  let id = r_actor.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor.actor.id!;
+  const r_actor = options.data.root.actor as LancerActor | undefined;
+  let id = r_actor?.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor?.id!;
   console.log(r_actor, id);
   let macroData = encodeMacroData({
     title: title,

--- a/src/module/interfaces.d.ts
+++ b/src/module/interfaces.d.ts
@@ -1,6 +1,6 @@
 import { LancerItemType } from "./item/lancer-item";
 import { EffectData } from "./helpers/npc";
-import { License, LiveEntryTypes } from "machine-mind";
+import { Damage, License, LiveEntryTypes } from "machine-mind";
 import { LancerActorType } from "./actor/lancer-actor";
 
 // ------------------------------------------------------
@@ -47,7 +47,7 @@ declare interface LancerAttackMacroData {
   title: string;
   grit: number;
   acc: number;
-  damage: DamageData[];
+  damage: Damage[];
   overkill?: boolean;
   effect?: EffectData | string;
   on_hit?: string; // For NPC weapons - to be removed once they use EffectData

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -29,7 +29,6 @@ import {
   OpCtx,
   Pilot,
   PilotWeapon,
-  RegDamageData,
   RegRef,
   TagInstance,
   Talent,
@@ -386,7 +385,7 @@ export async function renderMacroTemplate(actor: LancerActor | undefined, templa
   templateData._uuid = cardUUID;
 
   const html = await renderTemplate(template, templateData);
-  let roll: Roll | undefined;
+  //let roll: Roll | undefined;
   // Create JSON for the aggregate rolls.
   // TODO: Define these types
   let aggregate: any = {
@@ -396,6 +395,7 @@ export async function renderMacroTemplate(actor: LancerActor | undefined, templa
     terms: [],
     result: "",
   };
+  /*
   if (templateData.roll) {
     aggregate = templateData.roll;
   }
@@ -423,6 +423,21 @@ export async function renderMacroTemplate(actor: LancerActor | undefined, templa
   }
 
   roll = Roll.fromJSON(JSON.stringify(aggregate));
+  */
+  const agg: Roll[] = [];
+  if (templateData.roll) {
+    agg.push(templateData.roll);
+  }
+  if (templateData.attacks) {
+    agg.push(...templateData.attacks.map((a: { roll: Roll }) => a.roll));
+  }
+  if (templateData.crit_damages) {
+    agg.push(...templateData.crit_damages.map((d: { roll: Roll }) => d.roll));
+  } else if (templateData.damages) {
+    agg.push(...templateData.damages.map((d: { roll: Roll }) => d.roll));
+  }
+  const roll = Roll.fromTerms([PoolTerm.fromRolls(agg)]);
+
   return renderMacroHTML(actor, html, roll);
 }
 
@@ -739,20 +754,22 @@ async function prepareAttackMacro(
       mData.grit += options.accBonus;
     }
     if (options.damBonus) {
-      let i = mData.damage.findIndex((dam: RegDamageData) => {
-        return dam.type === options.damBonus.type;
+      let i = mData.damage.findIndex(dam => {
+        return dam.DamageType === options.damBonus.type;
       });
       if (i >= 0) {
         // We need to clone so it doesn't go all the way back up to the weapon
         let damClone = { ...mData.damage[i] };
-        if (damClone.val > 0) {
-          damClone.val = `${damClone.val}+${options.damBonus.val}`;
+        if (parseInt(damClone.Value) > 0) {
+          damClone.Value = `${damClone.Value}+${options.damBonus.val}`;
         } else {
-          damClone.val = options.damBonus.val;
+          damClone.Value = options.damBonus.val.toString();
         }
+        // @ts-expect-error Not the full class, but it should work for our purposes.
         mData.damage[i] = damClone;
       } else {
-        mData.damage.push(options.damBonus);
+        // @ts-expect-error Not the full class, but it should work for our purposes.
+        mData.damage.push({ Value: options.damBonus.val.toString(), DamageType: options.damBonus.type });
       }
     }
   }
@@ -957,7 +974,7 @@ async function rollAttackMacro(
     hits.find(hit => hit.hit && !hit.crit)
   ) {
     for (const x of data.damage) {
-      if (x.Value === "" || x.Value == 0) continue; // Skip undefined and zero damage
+      if (x.Value === "" || x.Value == "0") continue; // Skip undefined and zero damage
       let d_formula: string = x.Value.toString();
       let droll: Roll | null = new Roll(d_formula);
       // Add overkill if enabled.
@@ -981,7 +998,7 @@ async function rollAttackMacro(
         // Count overkill heat
         (<Die[]>droll.terms).forEach(p => {
           if (p.results && Array.isArray(p.results)) {
-            p.results.forEach((r: any) => {
+            p.results.forEach(r => {
               if (r.exploded) {
                 overkill_heat += 1;
               }
@@ -1003,11 +1020,11 @@ async function rollAttackMacro(
   if ((hits.length === 0 && attacks.find(attack => (attack.roll.total ?? 0) >= 20)) || hits.find(hit => hit.crit)) {
     // if (hits.length === 0 || hits.find(hit => hit.crit)) {
     for (const x of data.damage) {
-      if (x.Value === "" || x.Value == 0) continue; // Skip undefined and zero damage
+      if (x.Value === "" || x.Value == "0") continue; // Skip undefined and zero damage
       let d_formula: string = x.Value.toString();
       let droll: Roll | null = new Roll(d_formula);
       // double all dice, add KH. Add overkill if necessary.
-      (<Die[]>droll.terms).forEach(term => {
+      (<DiceTerm[]>droll.terms).forEach(term => {
         if (term.faces) {
           term.modifiers === undefined && (term.modifiers = []);
           if (data.overkill) {
@@ -1052,8 +1069,8 @@ async function rollAttackMacro(
     game.settings.get(game.system.id, LANCER.setting_automation) &&
     game.settings.get(game.system.id, LANCER.setting_overkill_heat)
   ) {
-    let mment: AnyMMActor = await actor.data.data.derived.mm_promise;
-    if (mment.Type === EntryType.MECH) {
+    let mment = await actor.data.data.derived.mm_promise;
+    if (is_reg_mech(mment)) {
       mment.CurrentHeat += overkill_heat;
       await mment.writeback();
     }
@@ -1077,6 +1094,63 @@ async function rollAttackMacro(
   console.debug(templateData);
   const template = `systems/${game.system.id}/templates/chat/attack-card.hbs`;
   return await renderMacroTemplate(actor, template, templateData);
+}
+
+/**
+ * Given an evaluated roll, create a new roll that doubles the dice and reuses
+ * the dice from the original roll.
+ * @returns An evaluated Roll
+ */
+async function getCritRoll(normal: Roll) {
+  const t_roll = new Roll(normal.formula);
+  await t_roll.evaluate({ async: true });
+
+  const dice_rolls = Array<DiceTerm.Result[]>(normal.terms.length);
+  const keep_dice: number[] = Array(normal.terms.length).fill(0);
+  normal.terms.forEach((term, i) => {
+    if (term instanceof DiceTerm) {
+      dice_rolls[i] = term.results.map(r => {
+        return { ...r };
+      });
+      keep_dice[i] = term.number;
+    }
+  });
+  t_roll.terms.forEach((term, i) => {
+    if (term instanceof DiceTerm) {
+      dice_rolls[i].push(...term.results);
+    }
+  });
+
+  // Just hold the active results in a sorted array, then mutate them
+  const actives: DiceTerm.Result[][] = Array(normal.terms.length).fill([]);
+  dice_rolls.forEach((dice, i) => {
+      actives[i] = dice.filter(d => d.active).sort((a, b) => a.result - b.result);
+  });
+  actives.forEach((dice, i) =>
+    dice.forEach((d, j) => {
+      d.active = j >= keep_dice[i];
+      d.discarded = j < keep_dice[i];
+    })
+  );
+
+  // We can rebuild him. We have the technology. We can make him better than he
+  // was. Better, stronger, faster
+  const terms = normal.terms.map((t, i) => {
+    if (t instanceof DiceTerm) {
+      return new Die({
+        ...t,
+        modifiers: (t.modifiers.filter(m => m.startsWith("kh")).length
+          ? t.modifiers
+          : [...t.modifiers, `kh${t.number}`]) as (keyof Die.Modifiers)[],
+        results: dice_rolls[i],
+        number: t.number * 2,
+      });
+    } else {
+      return t;
+    }
+  });
+
+  return Roll.fromTerms(terms);
 }
 
 /**

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -385,58 +385,22 @@ export async function renderMacroTemplate(actor: LancerActor | undefined, templa
   templateData._uuid = cardUUID;
 
   const html = await renderTemplate(template, templateData);
-  //let roll: Roll | undefined;
-  // Create JSON for the aggregate rolls.
-  // TODO: Define these types
-  let aggregate: any = {
-    class: "Roll",
-    dice: [],
-    formula: "",
-    terms: [],
-    result: "",
-  };
-  /*
-  if (templateData.roll) {
-    aggregate = templateData.roll;
-  }
-  if (templateData.attacks) {
-    const attacks: { roll: Roll; tt: string }[] = templateData.attacks;
-    attacks.forEach(atk => {
-      aggregate.formula += `+${atk.roll.formula}`;
-      if (aggregate.terms.length > 0) aggregate.terms.push("+");
-      atk.roll.terms.forEach(term => {
-        aggregate.terms.push(term);
-      });
-      aggregate.result += atk.roll.result;
-    });
-  }
-  if (templateData.damages) {
-    const damages: { roll: Roll; tt: string; d_type: string }[] = templateData.damages;
-    damages.forEach(dmg => {
-      aggregate.formula += `+${dmg.roll.formula}`;
-      if (aggregate.terms.length > 0) aggregate.terms.push("+");
-      dmg.roll.terms.forEach(term => {
-        aggregate.terms.push(term);
-      });
-      aggregate.result += dmg.roll.result;
-    });
-  }
 
-  roll = Roll.fromJSON(JSON.stringify(aggregate));
-  */
-  const agg: Roll[] = [];
+  // Schlorp up all the rolls into a mega-roll so DSN sees the stuff to throw
+  // on screen
+  const aggregate: Roll[] = [];
   if (templateData.roll) {
-    agg.push(templateData.roll);
+    aggregate.push(templateData.roll);
   }
   if (templateData.attacks) {
-    agg.push(...templateData.attacks.map((a: { roll: Roll }) => a.roll));
+    aggregate.push(...templateData.attacks.map((a: { roll: Roll }) => a.roll));
   }
   if (templateData.crit_damages) {
-    agg.push(...templateData.crit_damages.map((d: { roll: Roll }) => d.roll));
+    aggregate.push(...templateData.crit_damages.map((d: { roll: Roll }) => d.roll));
   } else if (templateData.damages) {
-    agg.push(...templateData.damages.map((d: { roll: Roll }) => d.roll));
+    aggregate.push(...templateData.damages.map((d: { roll: Roll }) => d.roll));
   }
-  const roll = Roll.fromTerms([PoolTerm.fromRolls(agg)]);
+  const roll = Roll.fromTerms([PoolTerm.fromRolls(aggregate)]);
 
   return renderMacroHTML(actor, html, roll);
 }

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -955,23 +955,11 @@ async function rollAttackMacro(
       await droll.evaluate({ async: true });
       const tt = await droll.getTooltip();
 
-      if (data.overkill && droll) {
-        // Count overkill heat
-        (<Die[]>droll.terms).forEach(p => {
-          if (p.results && Array.isArray(p.results)) {
-            p.results.forEach(r => {
-              if (r.exploded) overkill_heat += 1;
-            });
-          }
-        });
-      }
-      if (droll && tt) {
-        damage_results.push({
-          roll: droll,
-          tt: tt,
-          d_type: x.DamageType,
-        });
-      }
+      damage_results.push({
+        roll: droll,
+        tt: tt,
+        d_type: x.DamageType,
+      });
     }
   }
 
@@ -988,6 +976,19 @@ async function rollAttackMacro(
         });
       })
     );
+  }
+
+  // Calculate overkill heat
+  if (data.overkill) {
+    (has_crit_hit ? crit_damage_results : damage_results).forEach(result => {
+      result.roll.terms.forEach(p => {
+        if (p instanceof DiceTerm) {
+          p.results.forEach(r => {
+            if (r.exploded) overkill_heat += 1;
+          });
+        }
+      });
+    });
   }
 
   // TODO: Heat (self) application

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -969,7 +969,7 @@ async function rollAttackMacro(
   let overkill_heat = 0;
 
   const has_normal_hit =
-    (hits.length === 0 && !!attacks.find(attack => attack.roll.total ?? 0 < 20)) ||
+    (hits.length === 0 && !!attacks.find(attack => (attack.roll.total ?? 0) < 20)) ||
     !!hits.find(hit => hit.hit && !hit.crit);
   const has_crit_hit =
     (hits.length === 0 && !!attacks.find(attack => (attack.roll.total ?? 0) >= 20)) || !!hits.find(hit => hit.crit);
@@ -1013,15 +1013,17 @@ async function rollAttackMacro(
 
   // If there is at least one crit hit, evaluate crit damage
   if (has_crit_hit) {
-    damage_results.map(async result => {
-      const c_roll = await getCritRoll(result.roll);
-      const tt = await c_roll.getTooltip();
-      crit_damage_results.push({
-        roll: c_roll,
-        tt,
-        d_type: result.d_type,
-      });
-    });
+    await Promise.all(
+      damage_results.map(async result => {
+        const c_roll = await getCritRoll(result.roll);
+        const tt = await c_roll.getTooltip();
+        crit_damage_results.push({
+          roll: c_roll,
+          tt,
+          d_type: result.d_type,
+        });
+      })
+    );
   }
 
   // TODO: Heat (self) application
@@ -1072,7 +1074,8 @@ async function getCritRoll(normal: Roll) {
       dice_rolls[i] = term.results.map(r => {
         return { ...r };
       });
-      keep_dice[i] = term.number;
+      const kh = parseInt(term.modifiers.find(m => m.startsWith("kh"))?.substr(2) ?? "0");
+      keep_dice[i] = kh || term.number;
     }
   });
   t_roll.terms.forEach((term, i) => {


### PR DESCRIPTION
When creating critical hit rolls, instead of rolling an all new damage roll,
take the existing roll and smoosh it into a second new roll, then keep the
appropriate number of dice.

Apparently there's no existing issue for this one.
