### PR TITLE
Override the icon on ½ size mechs

### DIFF
--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -38,7 +38,11 @@
           {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "mm.Overshield"}}}
           {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "mm.CurrentRepairs" "mm.RepairCapacity"}}}
           <div class="size-card">
-            <i class="cci cci-size-{{mm.Size}} size-icon theme--main"></i>
+            {{#if (eq mm.Size 0.5)}}
+              <i class="cci cci-size-half size-icon theme--main"></i>
+            {{else}}
+              <i class="cci cci-size-{{mm.Size}} size-icon theme--main"></i>
+            {{/if}}
           </div>
           {{!-- {{{stat-view-card "SIZE" (concat "mdi " mm.SizeIcon) "mm.Size" }}} --}}
           {{{overcharge-button "mm.OverchargeCount"}}}

--- a/public/templates/actor/npc.hbs
+++ b/public/templates/actor/npc.hbs
@@ -34,7 +34,12 @@
         mdi-arrow-right-bold-hexagon-outline" "mm.Speed" }}} {{{stat-view-card "EVASION" "cci cci-evasion"
         "mm.Evasion" }}} {{{stat-view-card "E-DEF" "cci cci-edef" "mm.EDefense" }}} {{{stat-view-card "SENSORS"
         "cci cci-sensor" "mm.SensorRange" }}} {{{stat-view-card "SAVE" "cci cci-save" "mm.SaveTarget" }}}
-        {{{stat-view-card "SIZE" (concat "cci cci-size-" mm.Size) "mm.Size" }}} {{{stat-view-card "ACTIVATIONS"
+        {{#if (eq mm.Size 0.5)}}
+          {{{stat-view-card "SIZE" (concat "cci cci-size-half") "mm.Size" }}}
+        {{else}}
+          {{{stat-view-card "SIZE" (concat "cci cci-size-" mm.Size) "mm.Size" }}}
+        {{/if}}
+        {{{stat-view-card "ACTIVATIONS"
         "cci cci-activate" "mm.Activations" }}} {{{stat-edit-max-card "STRUCTURE" "cci cci-structure"
         "mm.CurrentStructure" "mm.MaxStructure" }}} {{{stat-edit-max-card "STRESS" "cci cci-reactor"
         "mm.CurrentStress" "mm.MaxStress"}}}


### PR DESCRIPTION
The cci font class for half sized mechs is cci-size-half, not
cci-size-0.5, so override manually to display that icon.
