### PR TITLE
Remove ref handler from actor and item portraits

### DIFF
--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -659,7 +659,7 @@ export class LancerActorSheet<T extends LancerActorType> extends ActorSheet<
   _propagateMMData(formData: any): any {
     // Pushes relevant field data from the form to other appropriate locations,
     // e.x. to synchronize name between token and actor
-    let token: any = this.actor.data["token"];
+    let token = this.actor.data["token"];
 
     // Get the basics
     let new_top: any = {

--- a/src/module/helpers/refs.ts
+++ b/src/module/helpers/refs.ts
@@ -229,7 +229,7 @@ export function mm_ref_portrait<T extends EntryType>(
   _helper: HelperOptions
 ) {
   // Fetch the image
-  return `<img class="profile-img ref valid ${item.Type}" src="${img}" data-edit="${img_path}" ${ref_params(
+  return `<img class="profile-img valid ${item.Type}" src="${img}" data-edit="${img_path}" ${ref_params(
     item.as_ref()
   )} width="100" height="100" />`;
 }


### PR DESCRIPTION
Using the ref handler on the portrait images would cause actor sheets to
force themselves in front of the file picker when attempting to edit the
image. This removes the ref css class from the images preventing the ref
handler from being unnecessarily added to the image edit control.
