### PR TITLE
Remove ref click handler from actor and item portraits

### DIFF
--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -77,7 +77,7 @@ export class LancerActorSheet<T extends LancerActorType> extends ActorSheet<
     this._activateActionGridListeners(html);
 
     // Make refs clickable to open the item
-    $(html).find(".ref.valid").on("click", HANDLER_activate_ref_clicking);
+    $(html).find(".ref.valid:not(.profile-img)").on("click", HANDLER_activate_ref_clicking);
 
     // Enable ref dragging
     HANDLER_activate_ref_dragging(html);
@@ -659,7 +659,7 @@ export class LancerActorSheet<T extends LancerActorType> extends ActorSheet<
   _propagateMMData(formData: any): any {
     // Pushes relevant field data from the form to other appropriate locations,
     // e.x. to synchronize name between token and actor
-    let token: any = this.actor.data["token"];
+    let token = this.actor.data["token"];
 
     // Get the basics
     let new_top: any = {

--- a/src/module/item/item-sheet.ts
+++ b/src/module/item/item-sheet.ts
@@ -78,7 +78,7 @@ export class LancerItemSheet<T extends LancerItemType> extends ItemSheet<ItemShe
     super.activateListeners(html);
 
     // Make refs clickable
-    $(html).find(".ref.valid").on("click", HANDLER_openRefOnClick);
+    $(html).find(".ref.valid:not(.profile-img)").on("click", HANDLER_openRefOnClick);
 
     // Enable ref dragging
     HANDLER_activate_ref_dragging(html);


### PR DESCRIPTION
Skip the profile-img class when determining which refs to add the click
handler to. This prevents actor sheets from forcing themselves to the
top when opening the file browser to change the portrait image.
