### PR TITLE
Add isAttack flag to MeasuredTemplates created by the accdiff dialog

### DIFF
--- a/src/module/helpers/acc_diff/Form.svelte
+++ b/src/module/helpers/acc_diff/Form.svelte
@@ -67,6 +67,7 @@
    const t = WeaponRangeTemplate.fromRange(range, token);
    if (!t) return;
    fade('out');
+   t.data.update({ [`flags.${game.system.id}.isAttack`]: true });
    t.placeTemplate()
      .catch(e => {
        console.warn(e);

--- a/src/module/pixi/weapon-range-template.ts
+++ b/src/module/pixi/weapon-range-template.ts
@@ -274,6 +274,7 @@ declare global {
           tokens: string[];
           dispositions: TokenDocument["data"]["disposition"][];
         };
+        isAttack?: boolean;
       };
     };
   }


### PR DESCRIPTION
Allows external integrations to filter what the source of a
MeasuredTemplate is in order to, for example, remove attack templates at
the end of a turn.
