### PR TITLE
Use concrete actor for prepareChargeMacro

### DIFF
--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -382,7 +382,7 @@ export class LancerActorSheet<T extends LancerActorType> extends ActorSheet<
     ChargeMacro.on("click", ev => {
       ev.stopPropagation(); // Avoids triggering parent event handlers
 
-      prepareChargeMacro(this.actor.id!);
+      prepareChargeMacro(this.actor);
     });
   }
 

--- a/src/module/helpers/automation/combat.ts
+++ b/src/module/helpers/automation/combat.ts
@@ -2,40 +2,41 @@ import type { LancerGame } from "../../lancer-game";
 import { prepareChargeMacro } from "../../macros";
 import { getAutomationOptions } from "../../settings";
 
-export async function handleCombatUpdate(combat: any, changed: any) {
+export async function handleCombatUpdate(...[combat, changed]: Parameters<Hooks.UpdateDocument<typeof Combat>>) {
   //if (combat.round === 0 || changed?.round === 0) return;
   if (!("turn" in changed) && changed.round !== 1) return;
-  if (game.combats!.get(combat.id)?.data?.combatants.contents.length == 0) return;
+  if (game.combats!.get(combat.id!)?.data?.combatants.contents.length == 0) return;
 
   const auto = getAutomationOptions();
   if (auto.enabled) {
     const nextTurnIndex = changed.turn;
-    const turnIndex = combat.current.turn;
+    // @ts-expect-error TODO: Debate foundry devs if this should be protected/private
+    const turnIndex = combat.current.turn!;
     if (combat.turns[nextTurnIndex]) {
       const nextToken = combat.turns[nextTurnIndex].token;
       const prevToken = combat.turns[turnIndex].token;
 
       // Handle next turn.
       if (nextToken) {
-        console.log(`Processing combat automation for ${nextToken.actor.id}`);
+        console.log(`Processing combat automation for ${nextToken.actor!.id}`);
 
         // Handle NPC charges.
-        prepareChargeMacro(nextToken.actor.id);
+        prepareChargeMacro(nextToken.actor!);
 
         // Refresh actions.
-        console.log(`Next up! Refreshing [${nextToken.actor.data.name}]!`);
-        (<LancerGame>game).action_manager?.modAction(nextToken.actor, false);
+        console.log(`Next up! Refreshing [${nextToken.actor!.data.name}]!`);
+        (<LancerGame>game).action_manager?.modAction(nextToken.actor!, false);
       }
 
       // Handle end-of-turn.
       if (prevToken) {
         // Dump extra actions.
         console.log(
-          `Turn over! [${prevToken.actor.data.name}] ended turn with ${JSON.stringify(
-            prevToken.actor.data.data.actions
+          `Turn over! [${prevToken.actor!.data.name}] ended turn with ${JSON.stringify(
+            prevToken.actor!.data.data.action_tracker
           )}`
         );
-        (<LancerGame>game).action_manager?.modAction(prevToken.actor, true);
+        (<LancerGame>game).action_manager?.modAction(prevToken.actor!, true);
       }
     }
   }

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -1410,11 +1410,11 @@ export function prepareStructureSecondaryRollMacro(registryId: string) {
   }
 }
 
-export async function prepareChargeMacro(a: string) {
+export async function prepareChargeMacro(a: string | LancerActor) {
   // Determine which Actor to speak as
-  let mech = getMacroSpeaker(a);
-  if (!mech || !mech.is_npc()) return;
-  const ent = mech.data.data.derived.mm;
+  let actor = getMacroSpeaker(a);
+  if (!actor || !actor.is_npc()) return;
+  const ent = actor.data.data.derived.mm;
   const feats = ent?.Features;
   if (!feats) return;
 
@@ -1440,13 +1440,13 @@ export async function prepareChargeMacro(a: string) {
 
   // Render template.
   const templateData = {
-    actorName: mech.name,
+    actorName: actor.name,
     roll: roll,
     roll_tooltip: roll_tt,
     changed: changed,
   };
   const template = `systems/${game.system.id}/templates/chat/charge-card.hbs`;
-  return renderMacroTemplate(mech, template, templateData);
+  return renderMacroTemplate(actor, template, templateData);
 }
 
 /**


### PR DESCRIPTION
If an npc had recharge systems and was unlinked, rolling for recharge
from the sheet or automatically on turn start via the action manager,
would use the sidebar actor unless the token was selected. By sending
the full document to prepareChargeMacro, this bypasses trying to re-find
the correct actor.

Update types on the action manager updateCombat hook.
