### PR TITLE
Structure/stress tweaks

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -143,11 +143,12 @@ export class LancerActor extends Actor {
   async rollOverHeatTable(reroll_data?: { stress: number }): Promise<void> {
     if (!this.is_mech() && !this.is_npc()) return;
     // Table of descriptions
-    function stressTableD(roll: number, remStress: number) {
+    function stressTableD(roll: number, remStress: number, maxStress: number) {
       switch (roll) {
         // Used for multiple ones
         case 0:
-          return "The reactor goes critical – your mech suffers a reactor meltdown at the end of your next turn.";
+          if (maxStress > 1) return "The reactor goes critical – your mech suffers a reactor meltdown at the end of your next turn.";
+          else if (maxStress <= 1) return "Your mech becomes @Compendium[world.status.EXPOSED].";
         case 1:
           switch (remStress) {
             case 2:
@@ -196,7 +197,7 @@ export class LancerActor extends Actor {
 
       let tt = await roll.getTooltip();
       let title = stressTableT[result];
-      let text = stressTableD(result, remStress);
+      let text = stressTableD(result, remStress, ent.MaxStress);
       let total = result.toString();
 
       let secondaryRoll = "";
@@ -204,7 +205,7 @@ export class LancerActor extends Actor {
       // Critical
       let one_count = (<Die[]>roll.terms)[0].results.filter(v => v.result === 1).length;
       if (one_count > 1) {
-        text = stressTableD(result, 1);
+        text = stressTableD(result, 1, ent.MaxStress);
         title = stressTableT[0];
         total = "Multiple Ones";
       } else {
@@ -236,7 +237,7 @@ export class LancerActor extends Actor {
     } else {
       // You ded
       let title = stressTableT[0];
-      let text = stressTableD(0, 0);
+      let text = stressTableD(0, 0, ent.MaxStress);
       templateData = {
         val: ent.CurrentStress,
         max: ent.MaxStress,

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -117,7 +117,7 @@ export class LancerActor extends Actor {
 
   /**
    * Performs overheat
-   * If automation is enabled, adjusts heat and stress and rolls if stress damage was taken, otherwise just roll on the table.
+   * If automation is enabled, this is called automatically by prepareOverheatMacro
    */
   async overheat(reroll_data?: { stress: number }): Promise<void> {
     // Assert that we're on a mech or NPC
@@ -126,8 +126,8 @@ export class LancerActor extends Actor {
       return;
     }
     const ent = await this.data.data.derived.mm_promise;
-    if (getAutomationOptions().structure && !reroll_data) {
-      if (ent.CurrentHeat > ent.HeatCapacity && ent.CurrentStress >= 0) {
+    if (!reroll_data) {
+      if (ent.CurrentHeat > ent.HeatCapacity && ent.CurrentStress > 0) {
         // https://discord.com/channels/426286410496999425/760966283545673730/789297842228297748
         if (ent.CurrentStress > 1) ent.CurrentHeat -= ent.HeatCapacity;
         ent.CurrentStress -= 1;
@@ -250,7 +250,7 @@ export class LancerActor extends Actor {
 
   /**
    * Performs structure on the mech
-   * For now, just rolls on table. Eventually we can include configuration to do automation
+   * If automation is enabled, this is called automatically by prepareStructureMacro
    */
   async structure(reroll_data?: { structure: number }) {
     // Assert that we're on a mech or NPC
@@ -259,8 +259,8 @@ export class LancerActor extends Actor {
       return;
     }
     const ent = await this.data.data.derived.mm_promise;
-    if (getAutomationOptions().structure && !reroll_data) {
-      if (ent.CurrentHP < 1 && ent.CurrentStructure >= 0) {
+    if (!reroll_data) {
+      if (ent.CurrentHP < 1 && ent.CurrentStructure > 0) {
         if (ent.CurrentStructure > 1) ent.CurrentHP += ent.MaxHP;
         ent.CurrentStructure -= 1;
       } else if (ent.CurrentHP >= 1) {


### PR DESCRIPTION
Some miscellaneous tweaks to the structure/stress prompt automation
- [x] Adjust values when the macro is called manually (if necessary based on hp or heat)
- [x] 1 stress NPCs should become exposed instead of meltdown. 
- [x] ~~Possibly just skip the prompt for 1 struct/stress npcs~~ Keeping it the same for now.
- [x] ~~Allow adding conditions from chatmessages context or a button?~~ This should be in a separate pr, and probably after a reorganization in macros.