### PR TITLE
Check for the bars container before redrawing token bars

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -954,7 +954,14 @@ export class LancerActor extends Actor {
 
         // Now that data is set properly, force token to draw its bars
         this.getActiveTokens().forEach(token => {
-          token.drawBars();
+          // Ensure the bars container exists before attempting to redraw the
+          // bars. This check is necessary because foundry doesn't initialize
+          // token components until draw is called.
+          // TODO: Remove token.bars part of check when 0.8 compat removed
+          // @ts-expect-error `bars` param not typed. `hud.bars` is in v9
+          if (token.bars || token.hud?.bars) {
+            token.drawBars();
+          }
         });
 
         return mm;


### PR DESCRIPTION
Foundry doesn't initialize the token components until the draw method is
called. This leads to a race condition where it is possible to drop a
token, then attempt to open the sheet, leading to drawBars to be called
before the canvas has drawn. This leads to sheets becoming un-openable
until a reload or update to the actor.

This contains a compatibility path for changes to tokens in v9 and will
work on both 0.8.x and v9.
