### PR TITLE
Remove unused .tag css rule

### DIFF
--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -309,18 +309,6 @@ button {
   flex-grow: 0;
 }
 
-.tag {
-  display: grid;
-  grid-template: 1em 1fr / 50px 1fr 50px;
-  align-items: center;
-  border: solid var(--main-theme-color, fuchsia);
-  border-color: var(--main-theme-color, fuchsia);
-  border-width: 1px;
-  border-radius: 5px;
-  border-left-width: 7px;
-  margin: 2px;
-}
-
 .tag-label {
   flex-grow: 0;
   display: flex;


### PR DESCRIPTION
This was from an older version of the sheets and was inadvertantly
making the module management unreadable for modules more than about 3
tags.
