### PR TITLE
Fix aws message (again)

### DIFF
--- a/src/module/helpers/compcon-login-form.ts
+++ b/src/module/helpers/compcon-login-form.ts
@@ -30,11 +30,9 @@ export default class CompconLoginForm extends FormApplication {
       populatePilotCache();
       return this.close();
     } catch (e) {
-      if (e instanceof Error) {
-        ui.notifications!.error(`Could not log in to Comp/Con: ${e.message}`);
-      } else {
-        ui.notifications!.error(`Could not log in to Comp/Con: ${e}`);
-      }
+      // AWS-amplify doesn't throw Errors for no apparent reason so ignore types and try our best
+      ui.notifications!.error(`Could not log in to Comp/Con: ${(e as any)?.message ?? e}`);
+      console.error(e);
     }
   }
 }


### PR DESCRIPTION
AWS amplify throws plain `Object`s so we have to ignore all typings and
just pretend we're in plain js land. Should work with thrown strings as
well, since all bets are off on what we might be getting.
