### PR TITLE
Remove LancerGame alias

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,6 @@
 import type { IContentPackManifest } from "machine-mind";
 import type { AutomationOptions } from "./module/settings";
+import type { LancerActionManager } from "./module/action/actionManager";
 
 declare global {
   // Since we never use these before `init` tell league types that they are
@@ -13,6 +14,12 @@ declare global {
     interface SystemData<T> {
       id: "lancer";
     }
+  }
+  interface Game {
+    lancer: {
+      [x: string]: unknown;
+    };
+    action_manager?: LancerActionManager;
   }
 
   namespace ClientSettings {

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -20,7 +20,6 @@ import {
   WELCOME,
   NEEDS_AUTOMATION_MIGRATION_VERSION,
 } from "./module/config";
-import type { LancerGame } from "./module/lancer-game";
 import { LancerActor } from "./module/actor/lancer-actor";
 import { LancerItem } from "./module/item/lancer-item";
 import { populatePilotCache } from "./module/compcon";
@@ -163,7 +162,7 @@ Hooks.once("init", async function () {
 
   // Assign custom classes and constants here
   // Create a Lancer namespace within the game global
-  (game as LancerGame).lancer = {
+  game.lancer = {
     applications: {
       LancerPilotSheet,
       LancerNPCSheet,
@@ -558,8 +557,8 @@ export const system_ready: Promise<void> = new Promise(success => {
     applyCollapseListeners();
     applyGlobalDragListeners();
 
-    (<LancerGame>game).action_manager = new LancerActionManager();
-    await (<LancerGame>game).action_manager!.init();
+    game.action_manager = new LancerActionManager();
+    await game.action_manager!.init();
 
     success();
   });
@@ -567,27 +566,27 @@ export const system_ready: Promise<void> = new Promise(success => {
 
 // Action Manager hooks.
 Hooks.on("controlToken", () => {
-  (<LancerGame>game).action_manager?.update();
+  game.action_manager?.update();
 });
 Hooks.on("updateToken", (_scene: Scene, _token: Token, diff: any, _options: any, _idUser: any) => {
   // If it's an X or Y change assume the token is just moving.
   if (diff.hasOwnProperty("y") || diff.hasOwnProperty("x")) return;
-  (<LancerGame>game).action_manager?.update();
+  game.action_manager?.update();
 });
 Hooks.on("updateActor", (_actor: Actor) => {
-  (<LancerGame>game).action_manager?.update();
+  game.action_manager?.update();
 });
 Hooks.on("closeSettingsConfig", () => {
-  (<LancerGame>game).action_manager?.updateConfig();
+  game.action_manager?.updateConfig();
 });
 Hooks.on("getSceneNavigationContext", async () => {
-  (<LancerGame>game).action_manager && (await (<LancerGame>game).action_manager!.reset());
+  game.action_manager && (await game.action_manager!.reset());
 });
 Hooks.on("createCombat", (_actor: Actor) => {
-  (<LancerGame>game).action_manager?.update();
+  game.action_manager?.update();
 });
 Hooks.on("deleteCombat", (_actor: Actor) => {
-  (<LancerGame>game).action_manager?.update();
+  game.action_manager?.update();
 });
 Hooks.on("updateCombat", (_combat: Combat, changes: DeepPartial<Combat["data"]>) => {
   if (getAutomationOptions().remove_templates && "turn" in changes && game.user?.isGM) {

--- a/src/module/actor/lancer-actor-sheet.ts
+++ b/src/module/actor/lancer-actor-sheet.ts
@@ -44,7 +44,6 @@ import type { FoundryFlagData } from "../mm-util/foundry-reg";
 import { mm_owner } from "../mm-util/helpers";
 import type { ActionType } from "../action";
 import { InventoryDialog } from "../apps/inventory";
-import type { LancerGame } from "../lancer-game";
 import { HANDLER_activate_item_context_menus } from "../helpers/item";
 const lp = LANCER.log_prefix;
 
@@ -252,10 +251,10 @@ export class LancerActorSheet<T extends LancerActorType> extends ActorSheet<
     let elements = html.find(".lancer-action-button");
     elements.on("click", async ev => {
       ev.stopPropagation();
-      if (!(<LancerGame>game).action_manager) return;
+      if (!game.action_manager) return;
 
       if (game.user?.isGM || game.settings.get(game.system.id, LANCER.setting_action_manager_players)) {
-        const manager = (<LancerGame>game).action_manager;
+        const manager = game.action_manager;
 
         const params = ev.currentTarget.dataset;
         const action = params.action as ActionType | undefined;

--- a/src/module/helpers/automation/combat.ts
+++ b/src/module/helpers/automation/combat.ts
@@ -1,4 +1,3 @@
-import type { LancerGame } from "../../lancer-game";
 import { prepareChargeMacro } from "../../macros";
 import { getAutomationOptions } from "../../settings";
 
@@ -25,7 +24,7 @@ export async function handleCombatUpdate(...[combat, changed]: Parameters<Hooks.
 
         // Refresh actions.
         console.log(`Next up! Refreshing [${nextToken.actor!.data.name}]!`);
-        (<LancerGame>game).action_manager?.modAction(nextToken.actor!, false);
+        game.action_manager?.modAction(nextToken.actor!, false);
       }
 
       // Handle end-of-turn.
@@ -36,7 +35,7 @@ export async function handleCombatUpdate(...[combat, changed]: Parameters<Hooks.
             prevToken.actor!.data.data.action_tracker
           )}`
         );
-        (<LancerGame>game).action_manager?.modAction(prevToken.actor!, true);
+        game.action_manager?.modAction(prevToken.actor!, true);
       }
     }
   }

--- a/src/module/lancer-game.ts
+++ b/src/module/lancer-game.ts
@@ -1,9 +1,0 @@
-import type { LancerActionManager } from "./action/actionManager";
-
-export class LancerGame extends Game {
-  // Create a lancer namespace
-  lancer!: {
-    finishedInit?: boolean;
-  } & Record<string, unknown>;
-  action_manager?: LancerActionManager;
-}

--- a/src/module/macros.ts
+++ b/src/module/macros.ts
@@ -42,7 +42,6 @@ import { checkForHit } from "./helpers/automation/targeting";
 import type { AccDiffData, AccDiffDataSerialized, RollModifier } from "./helpers/acc_diff";
 import { is_overkill, is_self_heat } from "machine-mind/dist/funcs";
 import type { LancerToken } from "./token";
-import { LancerGame } from "./lancer-game";
 import { getAutomationOptions } from "./settings";
 
 const lp = LANCER.log_prefix;
@@ -84,8 +83,8 @@ export async function runEncodedMacro(el: HTMLElement | LancerMacroData) {
     return;
   }
 
-  let fn = (game as LancerGame).lancer[data.fn];
-  return (fn as any).apply(null, data.args);
+  let fn = game.lancer[data.fn];
+  return (fn as Function).apply(null, data.args);
 }
 
 export async function onHotbarDrop(_bar: any, data: any, slot: number) {


### PR DESCRIPTION
Instead of using a fake class extension, use declaration merging to add
the lancer and action_manager parameters to the Game class, allowing
them to be accessed without asserting the type.
