### PR TITLE
fix(macro): Reset OverchargeCount on Full Repair

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -408,6 +408,7 @@ export class LancerActor extends Actor {
     if (is_reg_mech(ent)) {
       ent.CurrentCoreEnergy = 1;
       ent.CurrentRepairs = ent.RepairCapacity;
+      ent.OverchargeCount = 0
     }
 
     // I believe the only thing a pilot needs


### PR DESCRIPTION
# Description
This fix resets OverchargeCount for mechs upon calling `full_repair()`.

## Issue Number
Closes #368