### PR TITLE
Adding generic NPC tech attack, decomplecting stat macro, fixes #62 #129

### DIFF
--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -24,16 +24,13 @@
           {{{stat-edit-max-card "HEAT" "cci cci-heat" "mm.CurrentHeat" "mm.HeatCapacity"}}}
           {{{stat-view-card "EVASION" "cci cci-evasion" "mm.Evasion"}}}
           {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "mm.Armor"}}}
-          {{{stat-edit-max-card "STRUCTURE" "cci
-          cci-structure" "mm.CurrentStructure" "mm.MaxStructure"}}}
+          {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "mm.CurrentStructure" "mm.MaxStructure"}}}
           {{{stat-edit-max-card "STRESS" "cci cci-reactor" "mm.CurrentStress" "mm.MaxStress"}}}
-          {{{stat-view-card "E-DEF" "cci
-          cci-edef" "mm.EDefense"}}}
-          {{{stat-view-card "SPEED" "mdi
-          mdi-arrow-right-bold-hexagon-outline" "mm.Speed"}}}
+          {{{stat-view-card "E-DEF" "cci cci-edef" "mm.EDefense"}}}
+          {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "mm.Speed"}}}
           {{{stat-view-card "SAVE" "cci cci-save" "mm.SaveTarget"}}}
           {{{stat-view-card "SENSORS" "cci cci-sensor" "mm.SensorRange"}}}
-          {{{stat-rollable-card "TECH ATK" "cci cci-tech-full" "mm.TechAttack"}}}
+          {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "mm.TechAttack"}}}
           {{{stat-edit-card "BURN" "cci cci-burn" "mm.Burn"}}}
           {{{stat-edit-card "O.SHIELD" "mdi mdi-shield-star-outline" "mm.Overshield"}}}
           {{{stat-edit-max-card "REPAIRS" "cci cci-repair" "mm.CurrentRepairs" "mm.RepairCapacity"}}}

--- a/public/templates/actor/npc.hbs
+++ b/public/templates/actor/npc.hbs
@@ -25,24 +25,29 @@
       {{!-- Stats et all --}}
       <div class="wraprow quintuple">
         {{{clicker-stat-card "TIER" (concat "cci cci-npc-tier-" mm.Tier) "mm.Tier" true }}}
-        {{{stat-rollable-card "HULL" "" "mm.Hull" }}} {{{stat-rollable-card "AGI" "" "mm.Agi" }}}
-        {{{stat-rollable-card "SYS" "" "mm.Sys" }}} {{{stat-rollable-card "ENG" "" "mm.Eng" }}}
-        {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "mm.CurrentHP" "mm.MaxHP" }}} {{{stat-edit-max-card
-        "HEAT" "cci cci-heat" "mm.CurrentHeat" "mm.HeatCapacity" }}} {{{stat-view-card "ARMOR" "mdi mdi-shield-outline"
-        "mm.Armor" }}} {{{stat-edit-card "OVERSHIELD" "mdi mdi-shield-star-outline" "mm.Overshield" }}}
-        {{{stat-edit-card "BURN" "cci cci-burn" "mm.Burn" }}} {{{stat-view-card "SPEED" "mdi
-        mdi-arrow-right-bold-hexagon-outline" "mm.Speed" }}} {{{stat-view-card "EVASION" "cci cci-evasion"
-        "mm.Evasion" }}} {{{stat-view-card "E-DEF" "cci cci-edef" "mm.EDefense" }}} {{{stat-view-card "SENSORS"
-        "cci cci-sensor" "mm.SensorRange" }}} {{{stat-view-card "SAVE" "cci cci-save" "mm.SaveTarget" }}}
+        {{{stat-rollable-card "HULL" "" "mm.Hull" }}}
+        {{{stat-rollable-card "AGI" "" "mm.Agi" }}}
+        {{{stat-rollable-card "SYS" "" "mm.Sys" }}}
+        {{{stat-rollable-card "ENG" "" "mm.Eng" }}}
+        {{{stat-edit-max-card "HP" "mdi mdi-heart-outline" "mm.CurrentHP" "mm.MaxHP" }}}
+        {{{stat-edit-max-card "HEAT" "cci cci-heat" "mm.CurrentHeat" "mm.HeatCapacity" }}}
+        {{{stat-view-card "ARMOR" "mdi mdi-shield-outline" "mm.Armor" }}}
+        {{{stat-edit-card "OVERSHIELD" "mdi mdi-shield-star-outline" "mm.Overshield" }}}
+        {{{stat-edit-card "BURN" "cci cci-burn" "mm.Burn" }}}
+        {{{stat-view-card "SPEED" "mdi mdi-arrow-right-bold-hexagon-outline" "mm.Speed" }}}
+        {{{stat-view-card "EVASION" "cci cci-evasion" "mm.Evasion" }}}
+        {{{stat-view-card "E-DEF" "cci cci-edef" "mm.EDefense" }}}
+        {{{stat-view-card "SENSORS" "cci cci-sensor" "mm.SensorRange" }}}
+        {{{stat-view-card "SAVE" "cci cci-save" "mm.SaveTarget" }}}
         {{#if (eq mm.Size 0.5)}}
           {{{stat-view-card "SIZE" (concat "cci cci-size-half") "mm.Size" }}}
         {{else}}
           {{{stat-view-card "SIZE" (concat "cci cci-size-" mm.Size) "mm.Size" }}}
         {{/if}}
-        {{{stat-view-card "ACTIVATIONS"
-        "cci cci-activate" "mm.Activations" }}} {{{stat-edit-max-card "STRUCTURE" "cci cci-structure"
-        "mm.CurrentStructure" "mm.MaxStructure" }}} {{{stat-edit-max-card "STRESS" "cci cci-reactor"
-        "mm.CurrentStress" "mm.MaxStress"}}}
+        {{{stat-view-card "ACTIVATIONS" "cci cci-activate" "mm.Activations" }}}
+        {{{stat-edit-max-card "STRUCTURE" "cci cci-structure" "mm.CurrentStructure" "mm.MaxStructure" }}}
+        {{{stat-edit-max-card "STRESS" "cci cci-reactor" "mm.CurrentStress" "mm.MaxStress"}}}
+        {{{tech-flow-card "TECH ATK" "cci cci-tech-full" "mm.Sys"}}}
       </div>
 
       {{!-- Equipment et all --}}

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -105,6 +105,7 @@ import {
   stat_edit_card_max,
   stat_rollable_card,
   stat_view_card,
+  tech_flow_card,
 } from "./module/helpers/actor";
 import type { HelperOptions } from "handlebars";
 import {
@@ -362,6 +363,7 @@ Hooks.once("init", async function () {
   Handlebars.registerHelper("std-num-input", std_num_input);
   Handlebars.registerHelper("std-checkbox", std_checkbox);
   Handlebars.registerHelper("action-button", action_button);
+  Handlebars.registerHelper("tech-flow-card", tech_flow_card);
 
   // ------------------------------------------------------------------------
   // Tag helpers

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -183,6 +183,39 @@ export function action_button(
     `;
 }
 
+export function tech_flow_card(
+  title: string,
+  icon: string,
+  data_path: string,
+  options: HelperOptions
+): string {
+  let data_val = resolve_helper_dotpath(options, data_path);
+  // Determine whether this is an unlinked token, so we can encode the correct id for the macro.
+  const r_actor = options.data.root.actor as LancerActor | undefined;
+  let id = r_actor?.token && !r_actor.token.isLinked ? r_actor.token.id : r_actor?.id!;
+  // console.log(r_actor, id);
+
+  let macroData = encodeMacroData({
+    title: title,
+    fn: "prepareTechMacro",
+    args: [id, null],
+  });
+
+  return `
+    <div class="card clipped">
+      <div class="lancer-header ">
+        ${inc_if(`<i class="${icon} i--m i--light header-icon"> </i>`, icon)}
+        <span class="major">${title}</span>
+      </div>
+      <div class="flexrow stat-macro-container">
+      <a class="i--dark i--sm lancer-macro" data-macro="${macroData}"><i class="fas fa-dice-d20"></i></a>
+        <span class="lancer-stat major" data-path="${data_path}">${data_val}</span>
+        <div></div>
+      </div>
+    </div>
+    `;
+}
+
 export function npc_clicker_stat_card(title: string, data_path: string, options: HelperOptions): string {
   let data_val_arr: number[] = resolve_helper_dotpath(options, data_path) ?? [];
   let tier_clickers: string[] = [];

--- a/src/module/macros/attack.ts
+++ b/src/module/macros/attack.ts
@@ -26,12 +26,7 @@ import { checkForHit } from "../helpers/automation/targeting";
 import type { AccDiffData, AccDiffDataSerialized, RollModifier } from "../helpers/acc_diff";
 import { getMacroSpeaker, encodeMacroData, ownedItemFromString } from "./util"
 import { renderMacroTemplate } from "./render"
-import { rollReactionMacro } from "./reaction"
-import { rollSystemMacro } from "./system"
-import { rollTalentMacro } from "./talent"
-import { prepareTechMacro } from "./tech"
-import { rollTextMacro } from "./text"
-import { rollTriggerMacro } from "./trigger"
+
 
 const lp = LANCER.log_prefix;
 

--- a/src/module/macros/stat.ts
+++ b/src/module/macros/stat.ts
@@ -25,21 +25,8 @@ export async function prepareStatMacro(a: string, statKey: string, rerollData?: 
     title: statPath[statPath.length - 1].toUpperCase(),
     bonus: bonus,
   };
-  if (mData.title === "TECHATTACK") {
-    let partialMacroData = {
-      title: "Reroll stat macro",
-      fn: "prepareStatMacro",
-      args: [a, statKey],
-    };
-    rollTechMacro(
-      actor,
-      { acc: 0, action: "Quick", t_atk: bonus, effect: "", tags: [], title: "" },
-      partialMacroData,
-      rerollData
-    );
-  } else {
-    rollStatMacro(actor, mData).then();
-  }
+  
+  rollStatMacro(actor, mData).then();
 }
 
 // Rollers

--- a/src/module/macros/tech.ts
+++ b/src/module/macros/tech.ts
@@ -21,57 +21,81 @@ export async function prepareTechMacro(a: string, t: string, rerollData?: AccDif
   let actor = getMacroSpeaker(a);
   if (!actor) return;
 
-  // Get the item
-  const item = actor.items.get(t);
-  if (!item) {
-    return ui.notifications!.error(
-      `Error preparing tech attack macro - could not find Item ${t} owned by Actor ${a}! Did you add the Item to the token, instead of the source Actor?`
-    );
-  } else if (!item.isOwned) {
-    return ui.notifications!.error(`Error rolling tech attack macro - ${item.name} is not owned by an Actor!`);
-  }
 
   let mData: LancerTechMacroData = {
-    title: item.name!,
+    title: "",
     t_atk: 0,
     acc: 0,
     effect: "",
     tags: [],
     action: "",
   };
-  if (item.is_mech_system()) {
-    debugger;
-    /*
-    const tData = item.data.data as LancerMechSystemData;
-    mData.t_atk = (item.actor!.data as LancerPilotActorData).data.mech.tech_attack;
-    mData.tags = tData.tags;
-    mData.effect = ""; // TODO */
-  } else if (item.is_npc_feature()) {
-    const mm: NpcFeature = await item.data.data.derived.mm_promise;
-    let tier_index: number = mm.TierOverride;
-    if (!mm.TierOverride) {
-      if (item.actor === null && actor.is_npc()) {
-        // Use selected actor
-        tier_index = actor.data.data.tier - 1;
-      } else if (item.actor!.is_npc()) {
-        // Use provided actor
-        tier_index = item.actor.data.data.tier - 1;
-      }
+  let item: LancerItem | undefined;
+
+  if (!t) {
+    // if we weren't passed an item assume generic "basic tech attack" roll
+    // TODO: make an actual flow to this that lets people pick an action/invade/item
+    mData.action = "Quick";
+    mData.title = "BASIC"
+
+    if (actor.is_mech()) {
+      const mm = await actor.data.data.derived.mm_promise;
+      mData.t_atk = mm.TechAttack
+    } else if (actor.is_npc()) {
+      const mm = await actor.data.data.derived.mm_promise;
+      mData.t_atk = mm.Sys
     } else {
-      // Correct to be index
-      tier_index -= 1;
+      ui.notifications!.error(`Error rolling tech attack macro (not a valid tech attacker).`);
+      return Promise.resolve();
+    }
+  } else {
+    // Get the item
+    const item = actor.items.get(t);
+    if (!item) {
+      return ui.notifications!.error(
+        `Error preparing tech attack macro - could not find Item ${t} owned by Actor ${a}! Did you add the Item to the token, instead of the source Actor?`
+      );
+    } else if (!item.isOwned) {
+      return ui.notifications!.error(`Error rolling tech attack macro - ${item.name} is not owned by an Actor!`);
     }
 
-    mData.t_atk = mm.AttackBonus[tier_index] ?? 0;
-    mData.acc = mm.Accuracy[tier_index] ?? 0;
-    mData.tags = mm.Tags;
-    mData.effect = mm.Effect;
-    mData.action = mm.TechType;
-  } else {
-    ui.notifications!.error(`Error rolling tech attack macro`);
-    return Promise.resolve();
+    mData.title = item.name!;
+
+    if (item.is_mech_system()) {
+      debugger;
+      /*
+      const tData = item.data.data as LancerMechSystemData;
+      mData.t_atk = (item.actor!.data as LancerPilotActorData).data.mech.tech_attack;
+      mData.tags = tData.tags;
+      mData.effect = ""; // TODO */
+    } else if (item.is_npc_feature()) {
+      const mm: NpcFeature = await item.data.data.derived.mm_promise;
+      let tier_index: number = mm.TierOverride;
+      if (!mm.TierOverride) {
+        if (item.actor === null && actor.is_npc()) {
+          // Use selected actor
+          tier_index = actor.data.data.tier - 1;
+        } else if (item.actor!.is_npc()) {
+          // Use provided actor
+          tier_index = item.actor.data.data.tier - 1;
+        }
+      } else {
+        // Correct to be index
+        tier_index -= 1;
+      }
+  
+      mData.t_atk = mm.AttackBonus[tier_index] ?? 0;
+      mData.acc = mm.Accuracy[tier_index] ?? 0;
+      mData.tags = mm.Tags;
+      mData.effect = mm.Effect;
+      mData.action = mm.TechType;
+    } else {
+      ui.notifications!.error(`Error rolling tech attack macro`);
+      return Promise.resolve();
+    }
+    console.log(`${lp} Tech Attack Macro Item:`, item, mData);
   }
-  console.log(`${lp} Tech Attack Macro Item:`, item, mData);
+
 
   let partialMacroData = {
     title: "Reroll tech attack",


### PR DESCRIPTION
Adds a way to roll a "generic tech attack" on an NPC (which is the quick tech invade). Shouldn't have any breaking changes. I used branches that would previously be errors.

The eventual goal of some of the other pieces in adding this is to add a "quick tech" / "full tech" action flow for both NPCs and Mechs. By moving tech macros entirely out of the "stat" macros.

Also some clean up.