### PR TITLE
Stabilize, Full Repair, StructStress Macro QoL changes

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -398,6 +398,7 @@ export class LancerActor extends Actor {
   async full_repair() {
     let ent = await this.data.data.derived.mm_promise;
 
+    await this.remove_all_active_effects()
     ent.CurrentHP = ent.MaxHP;
     ent.Burn = 0;
     ent.Overshield = 0;
@@ -538,6 +539,14 @@ export class LancerActor extends Actor {
   async remove_active_effect(effect: string) {
     const target_effect = findEffect(this, effect)
     target_effect?.delete()
+  }
+
+  async remove_all_active_effects() {
+    let effectsToDelete = this.effects.filter(e => e.sourceName === "None")
+      .map(e => { 
+        return e.id ? e.id : '' 
+      });
+    await this.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
   }
 
   /**

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -398,7 +398,7 @@ export class LancerActor extends Actor {
   async full_repair() {
     let ent = await this.data.data.derived.mm_promise;
 
-    await this.remove_nontier_active_effects()
+    await this.remove_all_active_effects()
     ent.CurrentHP = ent.MaxHP;
     ent.Burn = 0;
     ent.Overshield = 0;

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -536,11 +536,18 @@ export class LancerActor extends Actor {
     );
   }
 
+  /**
+   * Locates an ActiveEffect on the Actor by name and removes it if present.
+   * @param effect String name of the ActiveEffect to remove.
+   */
   async remove_active_effect(effect: string) {
     const target_effect = findEffect(this, effect)
     target_effect?.delete()
   }
 
+  /**
+   * Wipes all ActiveEffects from the Actor.
+   */
   async remove_all_active_effects() {
     let effects_to_delete = this.effects.filter(e => e.sourceName === "None")
       .map(e => { 
@@ -549,6 +556,10 @@ export class LancerActor extends Actor {
     await this.deleteEmbeddedDocuments("ActiveEffect", effects_to_delete);
   }
 
+  /**
+   * Wipes all ActiveEffects that aren't NPC tiers from the Actor.
+   * May be subject to updates to protect additional ActiveEffects.
+   */
   async remove_nontier_active_effects() {
     let npc_tier_exp = /npc_tier_(\d)$/
     let effects_to_delete = this.effects.filter(e => {

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -399,6 +399,8 @@ export class LancerActor extends Actor {
     let ent = await this.data.data.derived.mm_promise;
 
     ent.CurrentHP = ent.MaxHP;
+    ent.Burn = 0;
+    ent.Overshield = 0;
 
     // Things for mechs & NPCs
     if (is_reg_mech(ent) || is_reg_npc(ent)) {

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -398,7 +398,7 @@ export class LancerActor extends Actor {
   async full_repair() {
     let ent = await this.data.data.derived.mm_promise;
 
-    await this.remove_all_active_effects()
+    await this.remove_nontier_active_effects()
     ent.CurrentHP = ent.MaxHP;
     ent.Burn = 0;
     ent.Overshield = 0;
@@ -542,11 +542,22 @@ export class LancerActor extends Actor {
   }
 
   async remove_all_active_effects() {
-    let effectsToDelete = this.effects.filter(e => e.sourceName === "None")
+    let effects_to_delete = this.effects.filter(e => e.sourceName === "None")
       .map(e => { 
-        return e.id ? e.id : '' 
+        return e.id ?? ''
       });
-    await this.deleteEmbeddedDocuments("ActiveEffect", effectsToDelete);
+    await this.deleteEmbeddedDocuments("ActiveEffect", effects_to_delete);
+  }
+
+  async remove_nontier_active_effects() {
+    let npc_tier_exp = /npc_tier_(\d)$/
+    let effects_to_delete = this.effects.filter(e => {
+      return e.sourceName === "None" && !npc_tier_exp.test(e.data.flags.core?.statusId ?? '')
+    })
+      .map(e => { 
+        return e.id ?? ''
+      });
+    await this.deleteEmbeddedDocuments("ActiveEffect", effects_to_delete);
   }
 
   /**

--- a/src/module/helpers/struct_stress/Form.svelte
+++ b/src/module/helpers/struct_stress/Form.svelte
@@ -14,12 +14,18 @@
     el.focus();
   }
 
+  function getCurrent(a: LancerActor | null) {
+    if (!a || (!a.is_mech() && !a.is_npc())) return 0;
+    return Math.max(a.data.data.derived[stat].value - 1, 0);
+  }
+
   function getDamage(a: LancerActor | null) {
     if (!a || (!a.is_mech() && !a.is_npc())) return 0;
-    return a.data.data.derived[stat].max - a.data.data.derived[stat].value + 1;
+    return a.data.data.derived[stat].max - getCurrent(a);
   }
 
   $: icon = stat === "stress" ? ("reactor" as const) : stat;
+  $: current = getCurrent(lancerActor);
   $: damage = getDamage(lancerActor);
 </script>
 
@@ -38,7 +44,7 @@
     <div class="message-body">
       <h3>{lancerActor?.name ?? "UNKNOWN MECH"} has taken {icon} damage!</h3>
       <div class="damage-preview">
-        {#each { length: lancerActor.data.data.derived[stat].value - 1 } as _}
+        {#each { length: current } as _}
           <i class="cci cci-{icon} i--m damage-pip" />
         {/each}
         {#each { length: damage } as _}


### PR DESCRIPTION
# Description
This change adds automated Burn clear to the Stabilize macro.  It also automatically clears the Exposed ActiveEffect, if present.

Biggest challenge I’m facing right now is figuring out how to get these automatic stat updates to play nice with CUB triggers and automated TokenMagicFX macros, though that is probably a personal mods+macros problem instead of a Lancer problem.

UPDATE: Also added Overshield + Burn clear to Full Repair macro.
UPDATE 2: Also added `remove_all_active_effects` and `remove_nontier_active_effects` methods to LancerActor (drawing from Foundry Community Macros for help); the former gets called by Full Repair (subject to change).
UPDATE 3: Limited the number of dice requested by the Struct/Stress Svelte popup to be the maximum Struct/Stress of the triggering actor.  Fixes the Svelte lockup described in #392.

## Issues Closed
Closes #391 
Closes #392
