### PR TITLE
[FEATURE] Damage calculation for Actors

### DIFF
--- a/src/module/actor/damage-calc.ts
+++ b/src/module/actor/damage-calc.ts
@@ -1,0 +1,29 @@
+import {
+  Damage,
+  DamageType,
+} from "machine-mind";
+
+export class AppliedDamage {
+  public Kinetic: number
+  public Energy: number
+  public Explosive: number
+  public Burn: number
+  public Heat: number
+  public Variable: number
+
+  public constructor(damageData: Damage[]) {
+    this.Kinetic = this.sum_damage(damageData, DamageType.Kinetic)
+    this.Energy = this.sum_damage(damageData, DamageType.Energy)
+    this.Explosive = this.sum_damage(damageData, DamageType.Explosive)
+    this.Burn = this.sum_damage(damageData, DamageType.Burn)
+    this.Heat = this.sum_damage(damageData, DamageType.Heat)
+    this.Variable = this.sum_damage(damageData, DamageType.Variable)
+  }
+  
+  public sum_damage(damageData: Damage[], damageType: DamageType): number {
+    return damageData.reduce((sum, d) => {
+      return sum + (d.DamageType === damageType ? parseInt(d.Value) : 0)
+    }, 0)
+  }
+  
+}

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -707,19 +707,27 @@ export class LancerActor extends Actor {
 
     if ("CurrentHeat" in ent) {
       ent.CurrentHeat += damage.Heat
+      await ent.writeback();
     }
     
     const armor_damage = Math.ceil(damage.Kinetic + damage.Energy + damage.Explosive + damage.Variable)
     let total_damage = armor_damage + damage.Burn
 
+    // Reduce Overshield first
     if (ent.Overshield) {
       const leftover_overshield = Math.max(ent.Overshield - total_damage, 0)
       total_damage = Math.max(total_damage - ent.Overshield, 0)
       ent.Overshield = leftover_overshield
+      await ent.writeback();
     }
 
+    // Finally reduce HP by remaining damage
     ent.CurrentHP -= total_damage
+    await ent.writeback();
+
+    // Add to Burn stat
     ent.Burn += damage.Burn
+    await ent.writeback();
 
     return total_damage
   }

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -670,8 +670,8 @@ export class LancerActor extends Actor {
       const resist_armor_damage = armored_damage_types.filter(t => ent.Resistances[t])
       const normal_armor_damage = armored_damage_types.filter(t => !ent.Resistances[t])
       const resist_ap_damage = ap_damage_types.filter(t => ent.Resistances[t])
-      let armor = ap ? ent.Armor : 0
-      let leftover_armor = armor
+      let armor = ap ? 0 : ent.Armor
+      let leftover_armor: number // Temp 'storage' variable for tracking used armor
 
       // Defender-favored: Deduct Armor from non-resisted damages first
       if (defense_favor) {

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -670,7 +670,7 @@ export class LancerActor extends Actor {
       const resist_armor_damage = armored_damage_types.filter(t => ent.Resistances[t])
       const normal_armor_damage = armored_damage_types.filter(t => !ent.Resistances[t])
       const resist_ap_damage = ap_damage_types.filter(t => ent.Resistances[t])
-      let armor = ap || paracausal ? ent.Armor : 0
+      let armor = ap ? ent.Armor : 0
       let leftover_armor = armor
 
       // Defender-favored: Deduct Armor from non-resisted damages first

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -22,6 +22,8 @@ import {
   Frame,
   RegMechData,
   RegNpcData,
+  Damage,
+  DamageType,
 } from "machine-mind";
 import { FoundryFlagData, FoundryReg } from "../mm-util/foundry-reg";
 import { LancerHooks, LancerSubscription } from "../helpers/hooks";
@@ -37,6 +39,7 @@ import { frameToPath } from "./retrograde-map";
 import { NpcClass } from "machine-mind";
 import { getAutomationOptions } from "../settings";
 import { findEffect } from "../helpers/acc_diff";
+import { AppliedDamage } from "./damage-calc"
 const lp = LANCER.log_prefix;
 
 // Use for HP, etc
@@ -624,6 +627,101 @@ export class LancerActor extends Actor {
         return ``;
     }
     return return_text;
+  }
+
+  async damage_calc(damage: AppliedDamage, ap=false, paracausal=false): Promise<number> {
+    const ent = await this.data.data.derived.mm_promise;
+
+    const armored_damage_types = [
+      "Kinetic",
+      "Energy",
+      "Explosive",
+      "Variable"
+    ] as const
+
+    const ap_damage_types = [
+      "Burn",
+      "Heat"
+    ] as const
+ 
+    // Entities without Heat Caps take Energy Damage instead
+    if (!("CurrentHeat" in ent)) {
+      damage.Energy += damage.Heat
+      damage.Heat = 0
+    }
+
+    // Step 1: Exposed doubles non-burn, non-heat damage
+    if (findEffect(this, 'exposed')) {
+      armored_damage_types.forEach(d => damage[d] *= 2)
+    }
+    
+    /** 
+     * FIXME - Once Deployables and Pilots have Resistances, only include the
+     * Shredded check.
+     */ 
+    /**
+     * Step 2: Reduce damage due to armor.
+     * Step 3: Reduce damage due to resistance.
+     * Armor reduction may favor attacker or defender depending on automation.
+     * Default is "favors defender".
+     */
+    if (!paracausal && !findEffect(this, 'shredded') && !is_reg_dep(ent) && !is_reg_pilot(ent)) {
+      const defense_favor = true; // getAutomationOptions().defenderArmor
+      const resist_armor_damage = armored_damage_types.filter(t => ent.Resistances[t])
+      const normal_armor_damage = armored_damage_types.filter(t => !ent.Resistances[t])
+      const resist_ap_damage = ap_damage_types.filter(t => ent.Resistances[t])
+      let armor = ap || paracausal ? ent.Armor : 0
+      let leftover_armor = armor
+
+      // Defender-favored: Deduct Armor from non-resisted damages first
+      if (defense_favor) {
+        for (const t of normal_armor_damage) {
+          leftover_armor = Math.max(armor - damage[t], 0)
+          damage[t] = Math.max(damage[t] - armor, 0)
+          armor = leftover_armor
+        }
+      }
+
+      // Deduct Armor from resisted damage
+      for (const t of resist_armor_damage) {
+        armor - damage[t]
+        leftover_armor = Math.max(armor - damage[t], 0)
+        damage[t] = Math.max(damage[t] - armor, 0)/2
+        armor = leftover_armor
+      }
+
+      // Attacker-favored: Deduct Armor from non-resisted damages first
+      if (!defense_favor) {
+        for (const t of normal_armor_damage) {
+          leftover_armor = Math.max(armor - damage[t], 0)
+          damage[t] = Math.max(damage[t] - armor)
+          armor = leftover_armor
+        }
+      }
+
+      // Resist Burn & Heat, unaffected by Armor
+      for (const t of resist_ap_damage) {
+        damage[t] = damage[t]/2
+      }
+    }
+
+    if ("CurrentHeat" in ent) {
+      ent.CurrentHeat += damage.Heat
+    }
+    
+    const armor_damage = Math.ceil(damage.Kinetic + damage.Energy + damage.Explosive + damage.Variable)
+    let total_damage = armor_damage + damage.Burn
+
+    if (ent.Overshield) {
+      const leftover_overshield = Math.max(ent.Overshield - total_damage, 0)
+      total_damage = Math.max(total_damage - ent.Overshield, 0)
+      ent.Overshield = leftover_overshield
+    }
+
+    ent.CurrentHP -= total_damage
+    ent.Burn += damage.Burn
+
+    return total_damage
   }
 
   // Imports packed pilot data, from either a vault id or gist id


### PR DESCRIPTION
# Description
This PR adds a damage-application function to Actors for later implementation.  It assumes that incoming damage is arranged in a `Damage[]` object. From there, it condenses all damage into a single `AppliedDamage` object, which simply tracks the total incoming damage for each damage type. 

It also assumes that "Heavy Gunner"-like features occur before the function is called.  The most complicated part was getting the "armor-application" logic correct when dealing with mixed damage types (i.e. to which damage pools is armor applied *first*).  

Notable features:

- Convert Heat to Energy if the actor lacks `CurrentHeat`.
- Doubles all non-Burn, non-Heat damage if the target is exposed ("Variable" is treated as Kinetic, Energy, or Explosive-typed since it usually is not possible to make it Burn or Heat).
- Reduce damage by Armor, with carry-over if there is leftover damage.
- Armor reduction applied in order depending to favoring attackers or defenders (defenders by default, automation option to come).
- Applying resistance for all "Resistances" possessed by the actor.
- Bypassing Armor and/or Resistance with `ap` and `paracausal` parameters.
- Applying Heat if the target if they have `CurrentHeat`.
- Applying damage to Overshield first, then to HP.