### PR TITLE
Rename the SLOWED condition

### DIFF
--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -60,8 +60,8 @@ export const STATUSES = [
     icon: `systems/lancer/assets/icons/white/condition_shredded.svg`,
   },
   {
-    id: "slow",
-    label: "Slow",
+    id: "slowed",
+    label: "Slowed",
     icon: `systems/lancer/assets/icons/white/condition_slow.svg`,
   },
   {


### PR DESCRIPTION
Renames the SLOWED condition from `slow` to `slowed` and updates the
label to match the core book better. People using CUB will want to
remake their conditions.

BoltsJ/lancer-speed-provider will need to have the logic for finding the
slowed condition updated to match.

Closes Eranziel/lancer-conditions#2
