### PR TITLE
Update lancer-initiative to take advantage of v9 features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "foundryvtt-lancer",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4791,9 +4791,9 @@
       "integrity": "sha512-ARii7p8oJxWETA7lOnOs4ya9XMa5gl4uhmrWkZ2aksk1GooyubCpb1QejhpLCVPngfIpapXR2kwD1zYhc83e+Q=="
     },
     "lancer-initiative": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lancer-initiative/-/lancer-initiative-1.1.0.tgz",
-      "integrity": "sha512-5vG4817ukHh12swotMn1m3AYBvejTe/ZjmtqZ7tejgGbyfgTMIxZA3B11WYXAE1kQ7hp84UN0aCQRMALX3TuxQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/lancer-initiative/-/lancer-initiative-2.0.1.tgz",
+      "integrity": "sha512-nLrouUD0oi8TjSaDGOBvS0R5Ktr3xbvb3tkJnM33OY5fzDo6K+ppk/ITl8EUDjOa3Q1pcSlkvfzVs6v9IWmhOw=="
     },
     "last-run": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "aws-amplify": "^4.2.9",
     "fp-ts": "^2.11.2",
     "io-ts": "^2.2.16",
-    "lancer-initiative": "^1.1.0",
+    "lancer-initiative": "^2.0.1",
     "machine-mind": "0.2.1",
     "marked": "^4.0.10",
     "tippy.js": "^6.3.1"

--- a/public/system.json
+++ b/public/system.json
@@ -3,7 +3,7 @@
   "title": "LANCER",
   "description": "A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.",
   "version": "1.1.0",
-  "minimumCoreVersion": "0.8.4",
+  "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
   "authors": [
     "Eranziel",

--- a/public/templates/combat/combat-tracker.hbs
+++ b/public/templates/combat/combat-tracker.hbs
@@ -22,7 +22,7 @@
         </nav>
         {{/if}}
 
-        <nav class="encounters flexrow">
+        <nav class="encounters flexrow {{#if hasCombat}}combat{{/if}}">
             {{#if user.isGM}}
             <a class="combat-control" title="{{localize 'COMBAT.RollAll'}}" data-control="rollAll" {{#unless turns}}disabled{{/unless}} {{#unless enable_initiative}}disabled{{/unless}}>
                 <i class="fas fa-users"></i>
@@ -34,18 +34,22 @@
 
             {{#if combatCount}}
             {{#if combat.data.round}}
-            <h3>{{localize 'COMBAT.Round'}} {{combat.data.round}}</h3>
+            <h3 class="encounter-title">{{localize 'COMBAT.Round'}} {{combat.data.round}}</h3>
             {{else}}
-            <h3>{{localize 'COMBAT.NotStarted'}}</h3>
+            <h3 class="encounter-title">{{localize 'COMBAT.NotStarted'}}</h3>
             {{/if}}
             {{else}}
-            <h3>{{localize "COMBAT.None"}}</h3>
+            <h3 class="encounter-title">{{localize "COMBAT.None"}}</h3>
             {{/if}}
 
             {{#if user.isGM}}
             <a class="combat-control" title="{{localize 'COMBAT.InitiativeReset'}}" data-control="resetAll"
                 {{#unless hasCombat}}disabled{{/unless}}>
                 <i class="fas fa-undo"></i>
+            </a>
+            <a class="combat-control" title="{{labels.scope}}"
+                data-control="toggleSceneLink" {{#unless hasCombat}}disabled{{/unless}}>
+                <i class="fas fa-{{#unless linked}}un{{/unless}}link"></i>
             </a>
             <a class="combat-settings" title="{{localize 'COMBAT.Settings'}}" data-control="trackerSettings">
                 <i class="fas fa-cog"></i>

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -228,6 +228,7 @@ Hooks.once("init", async function () {
   CONFIG.Token.objectClass = LancerToken;
   CONFIG.Combat.documentClass = LancerCombat;
   CONFIG.Combatant.documentClass = LancerCombatant;
+  // @ts-expect-error Because of mismatched versions of types
   CONFIG.ui.combat = LancerCombatTracker;
 
   // Set up system status icons


### PR DESCRIPTION
Updates lancer initiative to the v9 only 2.0.0 which no longer uses a
dummy combatant. This could potentially improve compatibility with
modules that incorrectly assume that actors and tokens are required to
be associated with combatants.

This also marks the system as _only_ v9 compatible (which it already
was).
