### PR TITLE
Implement new sharecode api endpoint for pilots, fix cache logic

### DIFF
--- a/public/templates/actor/pilot.hbs
+++ b/public/templates/actor/pilot.hbs
@@ -56,7 +56,7 @@
             {{#select vaultID}}
               <option value="">{{localize "lancer.pilot-sheet.cloud-header.vaultID"}}</option>
               {{#each pilotCache}}
-                <option value="{{cloudOwnerID}}//{{cloudID}}">{{name}}</option>
+                <option value="{{id}}">{{name}}</option>
               {{/each}}
             {{/select}}
           </select>

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -51,7 +51,7 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       // Cloud download
       let download = html.find('.cloud-control[data-action*="download"]');
       let actor = this.actor;
-      if (actor.is_pilot() && (actor.data.data.derived.mm!.CloudID)) {
+      if (actor.is_pilot() && actor.data.data.derived.mm!.CloudID) {
         download.on("click", async ev => {
           ev.stopPropagation();
 

--- a/src/module/compcon.ts
+++ b/src/module/compcon.ts
@@ -1,4 +1,3 @@
-import { AUDIO_FILE_EXTENSIONS } from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/constants.mjs";
 import type { PackedPilotData } from "machine-mind";
 import type { CachedCloudPilot } from "./interfaces";
 

--- a/src/module/compcon.ts
+++ b/src/module/compcon.ts
@@ -31,8 +31,8 @@ export async function populatePilotCache(): Promise<CachedCloudPilot[]> {
     await Promise.all(res.map((obj: { key: string }) => fetchPilot(obj.key)));
   data.forEach(pilot => {
     pilot.mechs = [];
-    pilot.cloudOwnerID = pilot.cloudOwnerID != null ? cleanCloudOwnerID(pilot.cloudOwnerID) : ""
-    pilot.cloudID = pilot.cloudID != null ? pilot.cloudID : pilot.id;
+    pilot.cloudOwnerID = pilot.cloudOwnerID != null ? cleanCloudOwnerID(pilot.cloudOwnerID) : "" // only clean the CloudOwnerID if its available
+    pilot.cloudID = pilot.cloudID != null ? pilot.cloudID : pilot.id; // if cloudID is present in the data being returned, use it. Otherwise, use the ID for selection purposes
   });
   _cache = data;
   return data;
@@ -101,6 +101,6 @@ export async function fetchPilot(cloudID: string, cloudOwnerID?: string): Promis
   }
   const res = (await Storage.get(cloudID, req)) as any;
   const text = await res.Body.text();
-  const json = JSON.parse(text);
-  return json;
+  return JSON.parse(text);
+
 }


### PR DESCRIPTION
This implements the new api endpoint for getting pilot data from a share code, as the vault codes have been deprecated.

additionally, this changes how the pilot data is gathered when a pilot is selected from the sync dropdown input after having authenticated - instead of relying on the cloudOwnerID and cloudID, it recreates the key to access aws-storage based on the pilot data that's returned within pilotCache.

note that the api key is currently hard-coded, depending on the results of testing how frequently these endpoints are hit, we may have to create an api key system setting in the future.