### PR TITLE
Fixing dist/public file watching somewhat.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,11 +43,23 @@ function build() {
   return cp.spawn("npx", ["vite", "build"], { stdio: "inherit", shell: true });
 }
 
+function _distWatcher() {
+  const publicDirPath = path.resolve(process.cwd(), "public");
+  const watcher = gulp.watch(["public/**/*.hbs"], { ignoreInitial: false });
+  watcher.on('change', async function(file, stats) {
+    console.log(`File ${file} was changed`);
+    const partial_file = path.relative(publicDirPath, file)
+    await fs.copy(path.join("public", partial_file), path.join("dist", partial_file));
+  });
+}
+
 function watch() {
+  _distWatcher();
   return cp.spawn("npx", ["vite", "build", "-w"], { stdio: "inherit", shell: true });
 }
 
 function serve() {
+  _distWatcher();
   // forward arguments on serves
   const serveArg = process.argv[2];
   let commands = ["vite", "serve"];


### PR DESCRIPTION
Adding file watching back to the gulp watch/serve features to better support modifying templates (an F5 is still required). This is a quality of life dev fix.