### PR TITLE
Update handleCombatUpdate for lancer-initiative 2.x

### DIFF
--- a/src/module/helpers/automation/combat.ts
+++ b/src/module/helpers/automation/combat.ts
@@ -4,38 +4,36 @@ import { getAutomationOptions } from "../../settings";
 export async function handleCombatUpdate(...[combat, changed]: Parameters<Hooks.UpdateDocument<typeof Combat>>) {
   //if (combat.round === 0 || changed?.round === 0) return;
   if (!("turn" in changed) && changed.round !== 1) return;
-  if (game.combats!.get(combat.id!)?.data?.combatants.contents.length == 0) return;
+  if ((game.combats!.get(combat.id!)?.turns.length ?? 0) === 0) return;
 
   const auto = getAutomationOptions();
   if (auto.enabled) {
-    const nextTurnIndex = changed.turn;
-    const turnIndex = combat.current.turn!;
-    if (combat.turns[nextTurnIndex]) {
-      const nextToken = combat.turns[nextTurnIndex].token;
-      const prevToken = combat.turns[turnIndex].token;
+    const nextTurnIndex = changed.turn as number | null;
+    const turnIndex = combat.current.turn;
+    const nextToken = nextTurnIndex === null ? undefined : combat.turns[nextTurnIndex].token;
+    const prevToken = turnIndex === null ? undefined : combat.turns[turnIndex].token;
 
-      // Handle next turn.
-      if (nextToken) {
-        console.log(`Processing combat automation for ${nextToken.actor!.id}`);
+    // Handle next turn.
+    if (nextToken) {
+      console.log(`Processing combat automation for ${nextToken.actor!.id}`);
 
-        // Handle NPC charges.
-        prepareChargeMacro(nextToken.actor!);
+      // Handle NPC charges.
+      prepareChargeMacro(nextToken.actor!);
 
-        // Refresh actions.
-        console.log(`Next up! Refreshing [${nextToken.actor!.data.name}]!`);
-        game.action_manager?.modAction(nextToken.actor!, false);
-      }
+      // Refresh actions.
+      console.log(`Next up! Refreshing [${nextToken.actor!.data.name}]!`);
+      game.action_manager?.modAction(nextToken.actor!, false);
+    }
 
-      // Handle end-of-turn.
-      if (prevToken) {
-        // Dump extra actions.
-        console.log(
-          `Turn over! [${prevToken.actor!.data.name}] ended turn with ${JSON.stringify(
-            prevToken.actor!.data.data.action_tracker
-          )}`
-        );
-        game.action_manager?.modAction(prevToken.actor!, true);
-      }
+    // Handle end-of-turn.
+    if (prevToken) {
+      // Dump extra actions.
+      console.log(
+        `Turn over! [${prevToken.actor!.data.name}] ended turn with ${JSON.stringify(
+          prevToken.actor!.data.data.action_tracker
+        )}`
+      );
+      game.action_manager?.modAction(prevToken.actor!, true);
     }
   }
 }


### PR DESCRIPTION
The function handleCombatUpdate was written with the assumption that
turn is never null, however in Foundry v9, turn can be set to null to
indicate no turn. The lancer-initiative library was updated to take
advantage of this, which causes errors when changing rounds, ending
turns, or selecting a turn when there's no acive combatant. Now, check
whether a referenced turn is null, and if so, skip tryitn to process
that turn.
