### PR TITLE
Fix NPC class/template feature removal behavior

### DIFF
--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -1316,6 +1316,17 @@ export function HANDLER_activate_item_context_menus<
       }
     },
   };
+  let remove_reference: ContextMenuEntry = {
+    name: "Remove",
+    icon: '<i class="fas fa-fw fa-trash"></i>',
+    callback: async (html: JQuery) => {
+      let sheet_data = await data_getter();
+      let path = html[0].dataset.path ?? "";
+      console.log(sheet_data, html, path);
+      array_path_edit(sheet_data, path, null, "delete");
+      await commit_func(sheet_data);
+    },
+  };
 
   // Counters are special so they unfortunately need dedicated controls
   let counter_edit: ContextMenuEntry = {
@@ -1365,12 +1376,17 @@ export function HANDLER_activate_item_context_menus<
   };
 
   let e_d_r = view_only ? [edit] : [edit, destroy, remove];
+  let e_d_rr = view_only ? [edit] : [edit, destroy, remove_reference];
   let e_r = view_only ? [edit] : [edit, remove];
 
   // Finally, setup the context menu
   tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"mech_weapon\"]`), "click", e_d_r);
   tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"mech_system\"]`), "click", e_d_r);
-  tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"npc_feature\"]`), "click", e_d_r);
+  if (html.offsetParent().hasClass('item')) {
+    tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"npc_feature\"]`), "click", e_d_rr);
+  } else {
+    tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"npc_feature\"]`), "click", e_d_r);
+  }
   tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"weapon_mod\"]`), "click", e_r);
   tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"pilot_weapon\"]`), "click", e_r);
   tippy_context_menu(html.find(`.lancer-context-menu[data-context-menu=\"pilot_armor\"]`), "click", e_r);


### PR DESCRIPTION
Before, when removing NPC features from NPC classes or templates, the
system would attempt to delete the feature. This is correct behavior for
Actors, but when this happens on an Item (e.g. NPC Class or Template),
this would either attempt to delete the feature from the Compendium
(throwing an error since the compendium is locked), or if the feature
was a custom feature added by the GM, the feature would be fully
deleted from the world and item list.

This commit changes removal behavior when the current sheet is an item
sheet, in which case, instead of calling destroy_entry(), the item is
spliced out of the correct list on the sheet (i.e. base features and
optional features).

Fixes #435