### PR TITLE
Fixed compcon pilot sync URL.

### DIFF
--- a/src/module/compcon.ts
+++ b/src/module/compcon.ts
@@ -53,7 +53,7 @@ export async function fetchPilotViaShareCode(sharecode: string): Promise<PackedP
 }
 
 export async function fetchPilotViaCache(cachedPilot: CachedCloudPilot): Promise<PackedPilotData> {
-  const documentID = `pilot/${cachedPilot.name}--${cachedPilot.id}--active`;
+  const documentID = `pilot/${cachedPilot.id}`;
   const { Storage } = await import("@aws-amplify/storage");
   const req: any = {
     level: "protected",


### PR DESCRIPTION
Pilot sync was returning a 404, so I reverted the uri format to how it was in 1.1.0.