### PR TITLE
Always show weapon mod drag target

### DIFF
--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2279,6 +2279,10 @@ Here, this means we want to allow for drag stuff etc to show contextually if:
   }
 }
 
+.drop-settable:not(.valid) {
+  align-items: center;
+}
+
 /* Separate, older version for tags */
 .ref-list-append.highlight-can-drop {
   visibility: visible;

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -628,11 +628,11 @@ export function mech_weapon_refview(
   } else {
     // Make a refbox, hidden
     mod_text = `
-    <div class="${EntryType.WEAPON_MOD} ref drop-settable context-drop highlight-can-drop card flexrow"
+    <div class="${EntryType.WEAPON_MOD} ref drop-settable card flexrow"
         data-path="${mod_path}"
         data-type="${EntryType.WEAPON_MOD}">
       <i class="cci cci-weaponmod i--m i--light"> </i>
-      <span>Insert Mod</span>
+      <span>No Mod Installed</span>
     </div>`;
   }
 


### PR DESCRIPTION
Also fix styling and reword target label so that it doesn't imply that
it's a bad thing that the weapon doesn't have a mod

Fixes #449 (Sort of. More like "addresses" #449.)