### PR TITLE
Add support for the Combat Carousel module

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -47,6 +47,7 @@ declare global {
       // "lancer.warningFor120": boolean; // Old setting, currently unused.
       // "lancer.warningForBeta": boolean; // Old setting, currently unused.
       'lancer.combatTrackerConfig': {sortTracker: boolean} | ClientSettings.Values['lancer.combatTrackerConfig'];
+      "lancer.combat-tracker-appearance": Partial<LancerInitiativeConfig["def_appearance"]>;
     }
   }
 }

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2398,6 +2398,49 @@ Here, this means we want to allow for drag stuff etc to show contextually if:
   }
 }
 
+#combat-carousel.lancer {
+  li.card {
+    div.lancer-activate {
+      a,
+      i {
+        font-size: var(--lancer-initiative-icon-size);
+      }
+
+      i.done {
+        color: var(--lancer-initiative-done-color);
+      }
+      position: absolute;
+      right: 0;
+      padding: 2px 0px;
+      border-radius: 25%;
+      z-index: 20;
+    }
+    text-align: left;
+    margin: 0px;
+  }
+
+  li.card.player {
+    div.lancer-activate a {
+      color: var(--lancer-initiative-player-color);
+    }
+  }
+  li.card.friendly {
+    div.lancer-activate a {
+      color: var(--lancer-initiative-friendly-color);
+    }
+  }
+  li.card.neutral {
+    div.lancer-activate a {
+      color: var(--lancer-initiative-neutral-color);
+    }
+  }
+  li.card.enemy {
+    div.lancer-activate a {
+      color: var(--lancer-initiative-enemy-color);
+    }
+  }
+}
+
 #combat #combat-tracker li.combatant.turn-done {
   // Furnace crap
   color: inherit;

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -154,6 +154,7 @@ import { gridDist } from "./module/helpers/automation/targeting";
 import CompconLoginForm from "./module/helpers/compcon-login-form";
 import { LancerCombat, LancerCombatant, LancerCombatTracker } from "lancer-initiative";
 import { LancerCombatTrackerConfig } from "./module/helpers/lancer-initiative-config-form";
+import { handleRenderCombatCarousel } from "./module/helpers/combat-carousel";
 
 const lp = LANCER.log_prefix;
 
@@ -530,6 +531,8 @@ Hooks.once("init", async function () {
   //     });
   //   }
   // });
+
+  Hooks.on("renderCombatCarousel", handleRenderCombatCarousel);
 });
 
 // TODO: either remove when sanity check is no longer needed, or find a better home.
@@ -631,6 +634,11 @@ Hooks.on("updateCombat", (_combat: Combat, changes: DeepPartial<Combat["data"]>)
     canvas.templates?.placeables.forEach(t => {
       if (t.document.getFlag("lancer", "isAttack")) t.document.delete();
     });
+  }
+  // This can be removed in v10
+  if (foundry.utils.hasProperty(changes, "turn")) {
+    // @ts-expect-error Just blindy try
+    ui.combatCarousel?.render();
   }
 });
 //

--- a/src/module/helpers/combat-carousel.ts
+++ b/src/module/helpers/combat-carousel.ts
@@ -1,0 +1,75 @@
+import type { LancerCombat, LancerCombatant } from "lancer-initiative";
+import { LancerCombatTrackerConfig } from "./lancer-initiative-config-form";
+
+const dispositions: Record<number, string> = {
+  [-2]: "",
+  [-1]: "enemy",
+  [0]: "neutral",
+  [1]: "friendly",
+  [2]: "player",
+};
+
+/**
+ * Hook to apply system specific customizations to the Combat Carousel UI
+ * @param app  - The Combat Carousel ui form
+ * @param html - The jquery data for the form
+ */
+export function handleRenderCombatCarousel(...[app, html]: Parameters<Hooks.RenderApplication<CombatCarousel>>) {
+  const icon = {
+    ...CONFIG.LancerInitiative.def_appearance,
+    ...(game.settings.get(CONFIG.LancerInitiative.module, "combat-tracker-appearance") ?? {}),
+  }.icon!;
+  html.addClass("lancer");
+  html.find("li.card").each((_, e) => {
+    const combatant_id = $(e).data("combatant-id");
+    const combatant = app.combat?.getEmbeddedDocument("Combatant", combatant_id) as LancerCombatant | undefined;
+    $(e).addClass(dispositions[combatant?.disposition ?? -2]);
+    const pending = combatant?.activations.value ?? 0;
+    const done = (combatant?.activations.max ?? 1) - pending;
+    $(e)
+      .find("div.initiative")
+      .before(
+        '<div class="lancer-activate">' +
+          `<a class="${icon} lancer-combat-control" data-control="activateCombatant"></a>`.repeat(pending) +
+          `<i class="${icon} lancer-combat-control done" data-control="deactivateCombatant"></i>`.repeat(done) +
+          "</div>"
+      );
+  });
+  html.find(".lancer-combat-control").on("click", ev => activateButton(app.combat, ev));
+  html.find("a.turn").hide();
+  html.find("div.initiative").hide();
+  html.find("a.encounter-control[data-action=rollNPC]").hide();
+  html.find("a.encounter-control[data-action=rollAll]").hide();
+  html
+    .find("a.encounter-control[data-action=config]")
+    .off("click")
+    .on("click", ev => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      new LancerCombatTrackerConfig(undefined).render(true);
+    });
+}
+
+function activateButton(
+  combat: LancerCombat | undefined | null,
+  ev: JQuery.ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+) {
+  ev.preventDefault();
+  ev.stopPropagation();
+  if (!combat) return;
+  const target = ev.currentTarget;
+  const combatant = target.closest<HTMLElement>(".card")?.dataset.combatantId;
+  if (!combatant) return;
+  switch (target.dataset.control) {
+    case "activateCombatant":
+      combat.activateCombatant(combatant);
+      break;
+    case "deactivateCombatant":
+      combat.deactivateCombatant(combatant);
+      break;
+  }
+}
+
+declare class CombatCarousel extends Application {
+  combat?: LancerCombat | null;
+}


### PR DESCRIPTION
This adds a hook to modify the UI of Combat Carousel making it work
analogously to lancer initiative. Specifically this hides useless
buttons and adds an activation button to the cards.

Additionally, this currently tweaks the CSS and adds to the updateCombat
hook to work around some minor incompatibilities.

Fixes #451
