### PR TITLE
Add delete button to NPC weapon tier damage

### DIFF
--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -142,10 +142,13 @@ export function damage_editor(path: string, options: HelperOptions) {
   let value_options = ext_helper_hash(options, { value: damage.Value });
   let value_input = std_string_input(path + ".Value", value_options);
 
+  let delete_button = `<a class="gen-control" data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
+
   return `<div class="flexrow flex-center" style="padding: 5px;">
     ${icon_html}
     ${damage_type_selector}
     ${value_input}
+    ${delete_button}
   </div>
   `;
 }


### PR DESCRIPTION
When editing an NPC feature (weapon), there was no delete button for weapon damage under each tier, making it easy to accidentally add extra damage to weapons. This PR adds a delete button to correct errors.

Demo: 
[Foundry_Virtual_Tabletop_2022-08-07_23-31-05.webm](https://user-images.githubusercontent.com/838450/183333426-2676f8b5-4a28-4ed0-8241-926e3e796787.webm)

