### PR TITLE
Fix roll aggregation for attack rolls

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -46,7 +46,8 @@ declare global {
       "lancer.autoCalcStructure": boolean;
       // "lancer.warningFor120": boolean; // Old setting, currently unused.
       // "lancer.warningForBeta": boolean; // Old setting, currently unused.
-      'lancer.combatTrackerConfig': {sortTracker: boolean} | ClientSettings.Values['lancer.combatTrackerConfig'];
+      "lancer.combatTrackerConfig": { sortTracker: boolean } | ClientSettings.Values["lancer.combatTrackerConfig"];
+      "lancer.dsnSetup": boolean;
     }
   }
 }

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -602,6 +602,15 @@ export const system_ready: Promise<void> = new Promise(success => {
   });
 });
 
+// Set up Dice So Nice to icrementally show attacks then damge rolls
+Hooks.once("ready", () => {
+  if (game.modules.get("dice-so-nice")?.active && !game.settings.get(game.system.id, LANCER.setting_dsn_setup)) {
+    console.log(`${lp} First login setup for Dice So Nice`);
+    game.settings.set("dice-so-nice", "enabledSimultaneousRollForMessage", false);
+    game.settings.set(game.system.id, LANCER.setting_dsn_setup, true);
+  }
+});
+
 // Action Manager hooks.
 Hooks.on("controlToken", () => {
   game.action_manager?.update();

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -179,6 +179,7 @@ export const LANCER = {
   setting_pilot_oc_heat: "autoOCHeat" as const,
   setting_overkill_heat: "autoOKillHeat" as const,
   setting_auto_structure: "autoCalcStructure" as const,
+  setting_dsn_setup: "dsnSetup" as const,
   // setting_120: "warningFor120" as const, // Old setting, currently unused.
   // setting_beta_warning: "warningForBeta" as const, // Old setting, currently unused.
   mech_items,

--- a/src/module/macros/_render.ts
+++ b/src/module/macros/_render.ts
@@ -1,9 +1,6 @@
 // Import TypeScript modules
-import { LANCER } from "../config";
 import type { LancerActor } from "../actor/lancer-actor";
 import { uuid4 } from "../helpers/collapse";
-
-const lp = LANCER.log_prefix;
 
 /**
  *
@@ -21,12 +18,12 @@ export async function renderMacroTemplate(actor: LancerActor | undefined, templa
   if (templateData.roll) {
     aggregate.push(templateData.roll);
   }
-  if (templateData.attacks) {
+  if ((templateData.attacks?.length ?? 0) > 0) {
     aggregate.push(...templateData.attacks.map((a: { roll: Roll }) => a.roll));
   }
-  if (templateData.crit_damages) {
+  if ((templateData.crit_damages?.length ?? 0) > 0) {
     aggregate.push(...templateData.crit_damages.map((d: { roll: Roll }) => d.roll));
-  } else if (templateData.damages) {
+  } else if ((templateData.damages?.length ?? 0) > 0) {
     aggregate.push(...templateData.damages.map((d: { roll: Roll }) => d.roll));
   }
   const roll = Roll.fromTerms([PoolTerm.fromRolls(aggregate)]);

--- a/src/module/macros/attack.ts
+++ b/src/module/macros/attack.ts
@@ -384,6 +384,8 @@ export async function checkTargets(
         let target = targetingData.target;
         let actor = target.actor as LancerActor;
         let attack_roll = await new Roll(targetingData.roll).evaluate({ async: true });
+        // @ts-expect-error DSN options aren't typed
+        attack_roll.dice.forEach(d => (d.options.rollOrder = 1));
         const attack_tt = await attack_roll.getTooltip();
 
         if (targetingData.usedLockOn) {
@@ -460,6 +462,8 @@ async function rollAttackMacro(
       }
 
       await droll.evaluate({ async: true });
+      // @ts-expect-error DSN options aren't typed
+      droll.dice.forEach(d => (d.options.rollOrder = 2));
       const tt = await droll.getTooltip();
 
       damage_results.push({
@@ -475,6 +479,8 @@ async function rollAttackMacro(
     await Promise.all(
       damage_results.map(async result => {
         const c_roll = await getCritRoll(result.roll);
+        // @ts-expect-error DSN options aren't typed
+        c_roll.dice.forEach(d => (d.options.rollOrder = 2));
         const tt = await c_roll.getTooltip();
         crit_damage_results.push({
           roll: c_roll,

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -93,6 +93,13 @@ export const registerSettings = function () {
     default: {},
   });
 
+  game.settings.register(game.system.id, LANCER.setting_dsn_setup, {
+    scope: "world",
+    config: false,
+    type: Boolean,
+    default: false,
+  });
+
   // Lancer initiative stuff
   CONFIG.LancerInitiative = {
     module: game.system.id,


### PR DESCRIPTION
The length of critical damage roll array was not properly checked so
the aggregation code was treating every roll as a critical, even if no
critical damage rolls were included.

I'm also going to see if I can make the attack and damage rolls show
separately without needing to split the cards.
