### PR TITLE
Add a setting for square grid measurement modes.

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -165,6 +165,14 @@
             "appearancesettingslabel": "Appearance Settings",
             "appearancesettingsbutton": "Appearance",
             "appearancesettings-desc": "Configure the colors and icon used in the tracker"
+        },
+        "squaregriddiagonals": {
+            "name": "Square Grid Diagonal Movement",
+            "hint": "How distances will be calculated when moving diagonally on a square grid.",
+            "111": "1-1-1: Diagonal moves cost 1 (default)",
+            "121": "1-2-1: Diagonal moves alternate cost from 1 to 2",
+            "222": "2-2-2: Manhattan distance. Diagonals cost 2",
+            "euc": "Euclidean: Euclidian distance rounded"
         }
     },
     "LANCERINITIATIVE": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -44,6 +44,7 @@ declare global {
       "lancer.autoOCHeat": boolean;
       "lancer.autoOKillHeat": boolean;
       "lancer.autoCalcStructure": boolean;
+      "lancer.squareGridDiagonals": "111" | "121" | "222" | "euc";
       // "lancer.warningFor120": boolean; // Old setting, currently unused.
       // "lancer.warningForBeta": boolean; // Old setting, currently unused.
       "lancer.combatTrackerConfig": { sortTracker: boolean } | ClientSettings.Values["lancer.combatTrackerConfig"];

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2279,6 +2279,10 @@ Here, this means we want to allow for drag stuff etc to show contextually if:
   }
 }
 
+.drop-settable:not(.valid) {
+  align-items: center;
+}
+
 /* Separate, older version for tags */
 .ref-list-append.highlight-can-drop {
   visibility: visible;

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -155,6 +155,7 @@ import CompconLoginForm from "./module/helpers/compcon-login-form";
 import { LancerCombat, LancerCombatant, LancerCombatTracker } from "lancer-initiative";
 import { LancerCombatTrackerConfig } from "./module/helpers/lancer-initiative-config-form";
 import { handleRenderCombatCarousel } from "./module/helpers/combat-carousel";
+import { measureDistances } from "./module/grid";
 
 const lp = LANCER.log_prefix;
 
@@ -612,6 +613,10 @@ Hooks.once("ready", () => {
     game.settings.set("dice-so-nice", "enabledSimultaneousRollForMessage", false);
     game.settings.set(game.system.id, LANCER.setting_dsn_setup, true);
   }
+});
+
+Hooks.once("canvasInit", () => {
+  SquareGrid.prototype.measureDistances = measureDistances;
 });
 
 // Action Manager hooks.

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -180,6 +180,7 @@ export const LANCER = {
   setting_overkill_heat: "autoOKillHeat" as const,
   setting_auto_structure: "autoCalcStructure" as const,
   setting_dsn_setup: "dsnSetup" as const,
+  setting_square_grid_diagonals: "squareGridDiagonals" as const,
   // setting_120: "warningFor120" as const, // Old setting, currently unused.
   // setting_beta_warning: "warningForBeta" as const, // Old setting, currently unused.
   mech_items,

--- a/src/module/grid.ts
+++ b/src/module/grid.ts
@@ -1,0 +1,30 @@
+import { LANCER } from "./config";
+
+export function measureDistances(
+  this: SquareGrid,
+  ...[segments, options = {}]: Parameters<SquareGrid["measureDistances"]>
+): ReturnType<SquareGrid["measureDistances"]> {
+  if (!options?.gridSpaces) return BaseGrid.prototype.measureDistances.call(this, segments, options);
+
+  const mode = game.settings.get(game.system.id, LANCER.setting_square_grid_diagonals);
+  const grid_distance = canvas.scene?.data.gridDistance ?? 0;
+  let diag_parity = 0; // Track the parity of the diagonals so that 121 can't be cheesed
+
+  return segments.map(s => {
+    const dx = Math.abs(Math.ceil(s.ray.dx / (canvas.dimensions?.size ?? 1)));
+    const dy = Math.abs(Math.ceil(s.ray.dy / (canvas.dimensions?.size ?? 1)));
+
+    switch (mode) {
+      case "111": // Diagonal movement costs 1
+        return Math.max(dx, dy) * grid_distance;
+      case "121": // Diagonal movement cost 1 then 2 then 1…
+        const d = Math.max(dx, dy) + Math.floor((Math.min(dx, dy) + diag_parity) / 2);
+        diag_parity = (diag_parity + Math.min(dx, dy)) % 2;
+        return d * grid_distance;
+      case "222": // Diagonal movement costs 2, there is no diagonal movement
+        return (dx + dy) * grid_distance;
+      case "euc": // Movement costs the straight line distance rounded to the nearest space
+        return Math.round(Math.hypot(dx, dy)) * grid_distance;
+    }
+  });
+}

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -631,11 +631,11 @@ export function mech_weapon_refview(
   } else {
     // Make a refbox, hidden
     mod_text = `
-    <div class="${EntryType.WEAPON_MOD} ref drop-settable context-drop highlight-can-drop card flexrow"
+    <div class="${EntryType.WEAPON_MOD} ref drop-settable card flexrow"
         data-path="${mod_path}"
         data-type="${EntryType.WEAPON_MOD}">
       <i class="cci cci-weaponmod i--m i--light"> </i>
-      <span>Insert Mod</span>
+      <span>No Mod Installed</span>
     </div>`;
   }
 

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -79,6 +79,20 @@ export const registerSettings = function () {
     default: false,
   });
 
+  game.settings.register(game.system.id, LANCER.setting_square_grid_diagonals, {
+    name: "lancer.squaregriddiagonals.name",
+    hint: "lancer.squaregriddiagonals.hint",
+    scope: "world",
+    config: true,
+    type: String,
+    choices: {
+      "111": "lancer.squaregriddiagonals.111",
+      "121": "lancer.squaregriddiagonals.121",
+      "222": "lancer.squaregriddiagonals.222",
+      "euc": "lancer.squaregriddiagonals.euc",
+    },
+  });
+
   game.settings.register(game.system.id, LANCER.setting_automation, {
     scope: "world",
     config: false,

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -91,6 +91,7 @@ export const registerSettings = function () {
       "222": "lancer.squaregriddiagonals.222",
       "euc": "lancer.squaregriddiagonals.euc",
     },
+    default: "111",
   });
 
   game.settings.register(game.system.id, LANCER.setting_automation, {


### PR DESCRIPTION
Since the rules on square grids in core are all but non-existent, it's up
to the GMs to arbitrate how diagonals work on them. This has options for
the four methods I've seen in various games.

* 1-1-1: This is the foundry default way. Diagonal movement costs 1
* 1-2-1: Diagonal movement alternates cost between 1 and 2
* 2-2-2: Manhattan distance. Diagonal movement costs 2
* Euclidian: Rounds the euclidian distance to the nearest grid space
