### PR TITLE
Add compatibility data to prevent loading on v10

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -1,10 +1,16 @@
 {
   "name": "lancer",
+  "id": "lancer",
   "title": "LANCER",
   "description": "A Foundry VTT game system for <a href=\"https://massif-press.itch.io/corebook-pdf\">Lancer</a> by <a href=\"https://massif-press.itch.io/\">Massif Press</a>, a mud-and-lasers tactical mech RPG.",
   "version": "1.2.0",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9",
+  "compatibility": {
+    "minimum": 9,
+    "verified": "9.280",
+    "maximum": 9
+  },
   "authors": [
     "Eranziel",
     "Grygon",


### PR DESCRIPTION
Since the system is non functional on v10, set the manifest
compatibility data to mark this as compatible with v9 only. This will
prevent foundry from loading and thus migrating worlds until a v10
release is made.
