### PR TITLE
fix(item): add delete button to range editors

### DIFF
--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -118,10 +118,13 @@ export function range_editor(path: string, options: HelperOptions) {
   let value_options = ext_helper_hash(options, { value: range.Value });
   let value_input = std_string_input(path + ".Value", value_options);
 
+  let delete_button = `<a class="gen-control" data-action="splice" data-path="${path}" style="margin: 4px;"><i class="fas fa-trash"></i></a>`;
+
   return `<div class="flexrow flex-center" style="padding: 5px;">
     ${icon_html}
     ${range_type_selector}
     ${value_input}
+    ${delete_button}
   </div>
   `;
 }


### PR DESCRIPTION
This does for Range editors what #454 did for damage editors, adding a "remove" option for unwanted ranged options.