### PR TITLE
Add @LancerID text enricher

### DIFF
--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -158,6 +158,8 @@ import { handleRenderCombatCarousel } from "./module/helpers/combat-carousel";
 import { measureDistances } from "./module/grid";
 import { fromLid, fromLidSync } from "./module/helpers/from-lid";
 
+import "./module/helpers/text-enrichers";
+
 const lp = LANCER.log_prefix;
 
 window.addEventListener("unhandledrejection", function (event) {

--- a/src/module/helpers/text-enrichers.ts
+++ b/src/module/helpers/text-enrichers.ts
@@ -8,12 +8,9 @@ CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
     enricher: async (match: string[], _opts: unknown) => {
       const lid = match[1];
       const label: string | undefined = match[2];
-      let doc:
-        | LancerActor
-        | LancerItem
-        | { _id: string; img: string; name: string; sort: number; system: { lid: string } }
-        // @ts-expect-error V10
-        | undefined = game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
+      let doc: LancerActor | LancerItem | { _id: string; name: string; system: { lid: string } } | undefined =
+        // @ts-expect-error v10
+        game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
       let databases = game.packs.filter(p => ["Actor", "Item"].includes(p.documentName));
       const data = {
         cls: ["content-link"],

--- a/src/module/helpers/text-enrichers.ts
+++ b/src/module/helpers/text-enrichers.ts
@@ -1,0 +1,85 @@
+import type { LancerActor } from "../actor/lancer-actor";
+import type { LancerItem } from "../item/lancer-item";
+
+//@ts-expect-error v10
+CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
+  {
+    pattern: /@LancerID\[(.+?)\](?:{(.+?)})?/g,
+    enricher: async (match: string[], _opts: unknown) => {
+      const lid = match[1];
+      const label: string | undefined = match[2];
+      let doc:
+        | LancerActor
+        | LancerItem
+        | { _id: string; img: string; name: string; sort: number; system: { lid: string } }
+        // @ts-expect-error V10
+        | undefined = game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
+      let databases = [
+        "tag",
+        "frame",
+        "core_bonus",
+        "mech_weapon",
+        "mech_system",
+        "weapon_mod",
+        "npc_class",
+        "npc_template",
+        "npc_feature",
+        "talent",
+        "pilot_armor",
+        "pilot_gear",
+        "pilot_weapon",
+        "skill",
+        "pilot",
+        "mech",
+        "npc",
+        "deployable",
+        "manufacturer",
+        "license",
+        "environment",
+        "faction",
+        "organization",
+        "reserve",
+        "sitrep",
+        "status",
+        "quirk",
+      ];
+      const data = {
+        cls: ["content-link"],
+        icon: undefined as string | undefined,
+        dataset: {} as Record<string, string>,
+        name: label,
+      };
+      while (!doc && databases.length > 0) {
+        const db = game.packs.get("world." + databases.pop());
+        if (!db) continue;
+        // @ts-expect-error You can use different fields
+        const index = await db.getIndex({ fields: ["system.lid"] });
+        // @ts-expect-error V10
+        doc = index.find(i => i.system.lid === lid);
+        // @ts-expect-error v10
+        if (doc) data.dataset.pack = db.metadata.id;
+      }
+      if (doc) {
+        if (doc instanceof foundry.abstract.Document) {
+          // @ts-expect-error v10
+          return doc.toAnchor({ attrs: { draggable: true }, classes: data.cls, name: data.name });
+        }
+        data.name ??= doc.name || lid;
+        const doc_type = game.packs.get(data.dataset.pack)?.documentName ?? "Item";
+        data.dataset.type = doc_type;
+        data.dataset.id = doc._id;
+        data.dataset.uuid = `Compendium.${data.dataset.pack}.${doc._id}`;
+        data.icon = CONFIG[doc_type].sidebarIcon;
+      } else {
+        data.cls.push("broken");
+        data.icon = "fas fa-unlink";
+      }
+      const a = document.createElement("a");
+      a.classList.add(...data.cls);
+      a.draggable = true;
+      Object.entries(data.dataset).forEach(([k, v]) => (a.dataset[k] = v));
+      a.innerHTML = `<i class="${data.icon}"></i>${data.name}`;
+      return a;
+    },
+  },
+]);

--- a/src/module/helpers/text-enrichers.ts
+++ b/src/module/helpers/text-enrichers.ts
@@ -14,35 +14,7 @@ CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
         | { _id: string; img: string; name: string; sort: number; system: { lid: string } }
         // @ts-expect-error V10
         | undefined = game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
-      let databases = [
-        "tag",
-        "frame",
-        "core_bonus",
-        "mech_weapon",
-        "mech_system",
-        "weapon_mod",
-        "npc_class",
-        "npc_template",
-        "npc_feature",
-        "talent",
-        "pilot_armor",
-        "pilot_gear",
-        "pilot_weapon",
-        "skill",
-        "pilot",
-        "mech",
-        "npc",
-        "deployable",
-        "manufacturer",
-        "license",
-        "environment",
-        "faction",
-        "organization",
-        "reserve",
-        "sitrep",
-        "status",
-        "quirk",
-      ];
+      let databases = game.packs.filter(p => ["Actor", "Item"].includes(p.documentName));
       const data = {
         cls: ["content-link"],
         icon: undefined as string | undefined,
@@ -50,10 +22,9 @@ CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
         name: label,
       };
       while (!doc && databases.length > 0) {
-        const db = game.packs.get("world." + databases.pop());
+        const db = databases.pop();
         if (!db) continue;
-        // @ts-expect-error You can use different fields
-        const index = await db.getIndex({ fields: ["system.lid"] });
+        const index = await db.getIndex();
         // @ts-expect-error V10
         doc = index.find(i => i.system.lid === lid);
         // @ts-expect-error v10


### PR DESCRIPTION
Allows linking items and actors by lid allowing world portable links in
journals.

It first searches the world collections, then the packs if nothing is found.
When searching the packs, it uses the index to avoid loading the document
unnecessarily.

This could be useful for people creating adventures as it allows journal links
to be created that aren't dependent on world IDs and could be used to list npc
features in a way that allows GMs to quickly recreate npcs without having to
include paid lcp data.

Example usage: `@LancerID[mf_standard_pattern_i_everest]`, `@LancerID[mw_shotgun]{Boomstick}`
