### PR TITLE
Add fromLid and fromLidSync functions

### DIFF
--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -156,6 +156,7 @@ import { LancerCombat, LancerCombatant, LancerCombatTracker } from "lancer-initi
 import { LancerCombatTrackerConfig } from "./module/helpers/lancer-initiative-config-form";
 import { handleRenderCombatCarousel } from "./module/helpers/combat-carousel";
 import { measureDistances } from "./module/grid";
+import { fromLid, fromLidSync } from "./module/helpers/from-lid";
 
 const lp = LANCER.log_prefix;
 
@@ -214,6 +215,8 @@ Hooks.once("init", async function () {
     targetsFromTemplate: macros.targetsFromTemplate,
     migrations: migrations,
     getAutomationOptions: getAutomationOptions,
+    fromLid: fromLid,
+    fromLidSync: fromLidSync,
 
     // For whitespines testing /('o')/
     tmp: {
@@ -228,7 +231,11 @@ Hooks.once("init", async function () {
 
   // Record Configuration Values
   CONFIG.Actor.documentClass = LancerActor;
+  // @ts-expect-error v10
+  CONFIG.Actor.compendiumIndexFields.push("system.lid");
   CONFIG.Item.documentClass = LancerItem;
+  // @ts-expect-error v10
+  CONFIG.Item.compendiumIndexFields.push("system.lid");
   CONFIG.Token.documentClass = LancerTokenDocument;
   CONFIG.Token.objectClass = LancerToken;
   CONFIG.Combat.documentClass = LancerCombat;

--- a/src/module/helpers/from-lid.ts
+++ b/src/module/helpers/from-lid.ts
@@ -1,0 +1,79 @@
+import type { LancerActor } from "../actor/lancer-actor";
+import type { LancerItem } from "../item/lancer-item";
+
+/**
+ * Retrieve a Document by its Lancer ID
+ * @param lid    - The Lancer ID to look up
+ * @param source - Where to look for the item
+ */
+export async function fromLid(lid: string, source: "all" | "world" | "compendium" = "all") {
+  const search_world = source === "all" || source === "world";
+  const search_compendium = source === "all" || source === "compendium";
+
+  let document: unknown;
+  if (search_world)
+    // @ts-expect-error v10
+    document = game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
+
+  if (!document && search_compendium) {
+    const databases = game.packs.filter(p => ["Actor", "Item"].includes(p.documentName));
+    await Promise.all(databases.map(d => d.getIndex()));
+    document = (
+      await Promise.all(
+        databases.map(db => {
+          // @ts-expect-error v10
+          const { _id: doc_id } = db.index.find(i => i.system?.lid === lid) ?? {};
+          return db.getDocument(doc_id ?? "");
+        })
+      )
+    ).find(e => e !== undefined);
+  }
+
+  return document as LancerActor | LancerItem | undefined;
+}
+
+/**
+ * Retrieve a Document by its Lancer ID synchronously. If the id
+ * resolves to a compendium, returns that document's index instead. If
+ * the index has not been regenerated to contain lids, only the world
+ * collections will be searched.
+ * @param lid    - The Lancer ID to look up
+ * @param source - Where to look for the item
+ */
+export function fromLidSync(lid: string, source: "all" | "world" | "compendium" = "all") {
+  const search_world = source === "all" || source === "world";
+  const search_compendium = source === "all" || source === "compendium";
+
+  let document: unknown;
+
+  if (search_world)
+    // @ts-expect-error v10
+    document = game.items?.find(i => i.system.lid === lid) ?? game.actors?.find(a => a.system.lid === lid);
+
+  if (!document && search_compendium) {
+    const databases = game.packs.filter(p => ["Actor", "Item"].includes(p.documentName));
+
+    document = databases
+      .map(db => {
+        // @ts-expect-error v10
+        const doc = db.index.find(i => i.system?.lid === lid);
+        if (doc) (<any>doc).pack = db.collection;
+        return doc;
+      })
+      .find(e => e !== undefined);
+  }
+
+  return document as
+    | LancerActor
+    | LancerItem
+    | {
+        _id: string;
+        img: string;
+        name: string;
+        pack: string;
+        sort: number;
+        type: string;
+        system: { lid: string };
+      }
+    | undefined;
+}


### PR DESCRIPTION
This pair of functions mirrors foundry core's fromUuid and
fromUuidSync functions allowing db lookups using just a LID. In order
to facilitate this functionality, system.lid is added as an index
field for actors and items.

Additionally, these functions are exposed on `game.lancer` for the convenience of module devs and macro writers