### PR TITLE
clarify that v10 works, add Lancer 3PL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lancer System for FoundryVTT
 A Foundry VTT system for the [Lancer RPG](https://massif-press.itch.io/corebook-pdf) by [Massif Press](https://massif-press.itch.io/). 
 
-**CAUTION:** Lancer does not yet have a stable release for Foundry v10. ***Do not*** launch your Lancer worlds on v10, as Foundry will automatically migrate your data and make it incompatible with v9. ***Always always always*** back up your data before updating Foundry!
+**CAUTION:** Lancer is now compatible with Foundry v10. If you launch your Lancer worlds on v10, Foundry will automatically migrate your data and make it incompatible with v9. ***Always always always*** back up your data before updating Foundry!
 
 ## Attribution and Acknowledgements
 The Lancer universe and all related setting materials are copyright Massif Press, used by permission.
@@ -25,3 +25,8 @@ Simply search for Lancer in the Foundry system browser and install from there.
 ## Development Setup
 
 [See here](https://github.com/Eranziel/foundryvtt-lancer/wiki/Development-Setup)
+
+## Legal
+"Lancer for FoundryVTT" is not an official _Lancer_ product; it is a third party work, and is not affiliated with Massif Press. "Lancer for FoundryVTT" is published via the _Lancer_ Third Party License.
+
+_Lancer_ is copyright Massif Press.


### PR DESCRIPTION
# Description

- [ ] Update the Readme to account for Lancer v1.4.1's compatibility with Foundry v10.
- [ ] Add [Lancer Third Party License](https://massifpress.com/legal) legalese at the bottom of the README.md.

It may be better to have the Third Party License in a separate LICENSE file? But it's hard to tell how it would interact with the GPL license that already exists. Figured at the very least it would be a good thing to have it front and center in the README.
