### PR TITLE
fixed issue #529 Mech tokens resetting to default image on import

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -1471,11 +1471,11 @@ export class LancerActor extends Actor {
     // Add manual check for the aws images
     if (
       // @ts-expect-error Should be fixed with v10 types
-      this.token?.img == oldFramePath ||
+      this.prototypeToken?.texture?.src == oldFramePath ||
       // @ts-expect-error Should be fixed with v10 types
-      this.token?.img == defaultImg ||
+      this.prototypeToken?.texture?.src == defaultImg ||
       // @ts-expect-error Should be fixed with v10 types
-      this.token?.img?.includes("compcon-image-assets")
+      this.prototypeToken?.texture?.src?.includes("compcon-image-assets")
     ) {
       newData.token = { img: newFramePath };
       changed = true;


### PR DESCRIPTION
I opened #529 a bit ago but recently had some time on my hands and figured I'd try fixing it myself

just changed token.img to prototypeToken.texture.src, which is the v10 path to the token image. 