### PR TITLE
fix(attacks): use new remove_active_effects to find lock on to consume

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -557,6 +557,18 @@ export class LancerActor extends Actor {
   }
 
   /**
+   * Locates ActiveEffects on the Actor by names provided and removes them if present.
+   * @param effects Array of String names of the ActiveEffects to remove.
+   */
+  async remove_active_effects(effects: string[]) {
+    const target_effects = effects.map(e => findEffect(this, e));
+    this.deleteEmbeddedDocuments(
+      "ActiveEffect",
+      target_effects.map(e => e?.id || "")
+    );
+  }
+
+  /**
    * Wipes all ActiveEffects from the Actor.
    */
   async remove_all_active_effects() {

--- a/src/module/macros/attack.ts
+++ b/src/module/macros/attack.ts
@@ -21,6 +21,7 @@ import { is_loading, is_self_heat } from "machine-mind/dist/classes/mech/EquipUt
 import { FoundryReg } from "../mm-util/foundry-reg";
 import { checkForHit } from "../helpers/automation/targeting";
 import type { AccDiffData, AccDiffDataSerialized, RollModifier } from "../helpers/acc_diff";
+import { findEffect } from "../helpers/acc_diff";
 import { getMacroSpeaker, ownedItemFromString } from "./_util";
 import { encodeMacroData } from "./_encode";
 import { renderMacroTemplate } from "./_render";
@@ -623,9 +624,14 @@ Hooks.on("createChatMessage", async (cm: ChatMessage, options: any, id: string) 
       } else {
         // Remove status
         console.log(`Removing ${stat} from Token ${target.id}`);
-        tokenActor?.remove_active_effect(stat);
+        const effect = findEffect(tokenActor, stat);
+        statusToRemove.push(effect);
       }
     }
+    tokenActor?.deleteEmbeddedDocuments(
+      "ActiveEffect",
+      statusToRemove.map(e => e?.id || "")
+    );
   });
 });
 

--- a/src/module/macros/attack.ts
+++ b/src/module/macros/attack.ts
@@ -623,14 +623,9 @@ Hooks.on("createChatMessage", async (cm: ChatMessage, options: any, id: string) 
       } else {
         // Remove status
         console.log(`Removing ${stat} from Token ${target.id}`);
-        const effects = tokenActor.effects.filter(e => e.getFlag("core", "statusId") === stat) || [];
-        statusToRemove.push(...effects);
+        tokenActor?.remove_active_effect(stat);
       }
     }
-    tokenActor?.deleteEmbeddedDocuments(
-      "ActiveEffect",
-      statusToRemove.map(e => e.id || "")
-    );
   });
 });
 

--- a/src/module/macros/attack.ts
+++ b/src/module/macros/attack.ts
@@ -21,7 +21,6 @@ import { is_loading, is_self_heat } from "machine-mind/dist/classes/mech/EquipUt
 import { FoundryReg } from "../mm-util/foundry-reg";
 import { checkForHit } from "../helpers/automation/targeting";
 import type { AccDiffData, AccDiffDataSerialized, RollModifier } from "../helpers/acc_diff";
-import { findEffect } from "../helpers/acc_diff";
 import { getMacroSpeaker, ownedItemFromString } from "./_util";
 import { encodeMacroData } from "./_encode";
 import { renderMacroTemplate } from "./_render";
@@ -624,14 +623,10 @@ Hooks.on("createChatMessage", async (cm: ChatMessage, options: any, id: string) 
       } else {
         // Remove status
         console.log(`Removing ${stat} from Token ${target.id}`);
-        const effect = findEffect(tokenActor, stat);
-        statusToRemove.push(effect);
+        statusToRemove.push(stat);
       }
     }
-    tokenActor?.deleteEmbeddedDocuments(
-      "ActiveEffect",
-      statusToRemove.map(e => e?.id || "")
-    );
+    tokenActor?.remove_active_effects(statusToRemove);
   });
 });
 


### PR DESCRIPTION
# Description
Create a new `remove_active_effects` function on `LancerActor` that allows for an array of effect names to be passed to the function for deletion. Using this new function to remove the Lock On status from an actor after an attack that Consumes Lock On. This allows for fuzzier effect finding that plays nicer with Combat Utility Belt's Condition Lab.

First couple commits had some alternative methods of solving this problem; I prefer this one since it creates a new function that LancerActor can leverage in the future that batches all deletions into a single call.

## Issue Number
Closes #543