### PR TITLE
Update maximum version to 11

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -8,7 +8,7 @@
   "compatibility": {
     "minimum": 10,
     "verified": "10.291",
-    "maximum": 10
+    "maximum": 11
   },
   "authors": [
     {"name": "Eranziel"},


### PR DESCRIPTION
Recently Foundry 11 released. Currently the `system.json` limits Lancer to only running in version 10.

After updating the maximum version I was able to load up a new world with the Lancer system, I was able to create a pilot, and there were no errors in the console. There was one minor deprecation warning, but that reportedly existed in Foundry 10.