### PR TITLE
2.0 tag fixups

### DIFF
--- a/public/templates/chat/attack-card.hbs
+++ b/public/templates/chat/attack-card.hbs
@@ -123,5 +123,5 @@
       <span class="effect-text collapse" data-collapse-id="{{_uuid}}-effect">{{{on_crit}}}</span>
     </div>
   {{/if}}
-  {{{tag-list tags tags}}}
+  {{{tag-list "tags"}}}
 </div>

--- a/public/templates/chat/generic-card.hbs
+++ b/public/templates/chat/generic-card.hbs
@@ -5,6 +5,6 @@
         <div class="effect-text" style="grid-area: 2/1/3/3">
             {{{description}}}
         </div>
-        {{{tag-list tags}}}
+        {{{tag-list "tags"}}}
     </div>
 </div>

--- a/public/templates/chat/reaction-card.hbs
+++ b/public/templates/chat/reaction-card.hbs
@@ -12,6 +12,6 @@
               {{{effect}}}
             </div>
           </div>
-        {{{tag-list tags}}}
+        {{{tag-list "tags"}}}
     </div>
 </div>

--- a/public/templates/chat/tech-attack-card.hbs
+++ b/public/templates/chat/tech-attack-card.hbs
@@ -56,6 +56,6 @@
   </div>
   {{/if}}
   <div class="flexrow" style="justify-content: flex-end; flex-wrap: wrap;">
-    {{{tag-list tags tags}}}
+    {{{tag-list "tags"}}}
   </div>
 </div>

--- a/public/templates/item/frame.hbs
+++ b/public/templates/item/frame.hbs
@@ -133,11 +133,6 @@
         todo action
       {{/each}}
     </div>
-    <div class="tags-container" style="margin: 10px;">
-      <div class="flexcol lancer-title">
-        <span class="major">TAGS</span>
-        {{{tag-list "system.core_system.tags" system.core_system.tags editable}}}
-      </div>
-    </div>
+    {{{item-edit-arrayed-tags "system.core_system.tags" "TAGS"}}}
   </div>
 </form>

--- a/public/templates/item/mech_system.hbs
+++ b/public/templates/item/mech_system.hbs
@@ -41,11 +41,6 @@
     <div class="flexrow">
     </div>
 
-    {{!-- Tags --}}
-    <div class="card">
-      <span class="lancer-header major">TAGS</span>
-      {{{tag-list "system.tags" system.tags editable}}}
-    </div>
-
+    {{{item-edit-arrayed-tags "system.tags" "TAGS"}}}
   </div>
 </form>

--- a/public/templates/item/mech_weapon.hbs
+++ b/public/templates/item/mech_weapon.hbs
@@ -80,10 +80,7 @@
           {{{item-edit-arrayed-actions (concat "system.profiles." prof_index ".actions") "ADDED ACTIONS"}}}
 
           {{!-- Tags --}}
-          <div class="card full">
-            <span class="lancer-header submajor">TAGS</span>
-            {{{tag-list (concat "system.profiles." prof_index ".tags") profile.tags ../editable}}}
-          </div>
+          {{{item-edit-arrayed-tags (concat "system.profiles." prof_index ".tags") "TAGS" }}}
         </div>
       </div>
       {{/each}}

--- a/public/templates/item/npc_feature.hbs
+++ b/public/templates/item/npc_feature.hbs
@@ -166,13 +166,6 @@
         {{{textarea-card "EFFECT" "system.effect"}}}
       </div>
     {{/if}}
-    {{! Tags }}
-    <div class="card full">
-      <div class="lancer-header major">
-        <span>TAGS</span>
-        <a class="gen-control fas fa-plus" data-action="append" data-path="system.tags" data-action-value="(struct)tag"></a>
-      </div>
-      {{{tag-list "system.tags" system.tags editable}}}
-    </div>
+    {{{item-edit-arrayed-tags "system.tags" "TAGS"}}}
   </section>
 </form>

--- a/public/templates/item/npc_feature.hbs
+++ b/public/templates/item/npc_feature.hbs
@@ -168,9 +168,10 @@
     {{/if}}
     {{! Tags }}
     <div class="card full">
-      <span class="lancer-header major">
-        TAGS
-      </span>
+      <div class="lancer-header major">
+        <span>TAGS</span>
+        <a class="gen-control fas fa-plus" data-action="append" data-path="system.tags" data-action-value="(struct)tag"></a>
+      </div>
       {{{tag-list "system.tags" system.tags editable}}}
     </div>
   </section>

--- a/public/templates/item/pilot_armor.hbs
+++ b/public/templates/item/pilot_armor.hbs
@@ -25,10 +25,5 @@
   {{{item-edit-arrayed-deployables  "system.deployables"    "DEPLOYABLES"}}}
   {{{item-edit-arrayed-synergies    "system.synergies"      "SYNERGIES"}}}
 
-  {{!-- Tags --}}
-  <div class="card">
-    <span class="lancer-header major">TAGS</span>
-    {{{tag-list "system.tags" system.tags editable}}}
-  </div>
-
+  {{{item-edit-arrayed-tags "system.tags" "TAGS"}}}
 </form>

--- a/public/templates/item/pilot_gear.hbs
+++ b/public/templates/item/pilot_gear.hbs
@@ -28,12 +28,7 @@
     {{{item-edit-arrayed-deployables  "system.deployables"  "DEPLOYABLES"}}}
     {{{item-edit-arrayed-synergies    "system.synergies"    "SYNERGIES"}}}
 
-    {{!-- Tags --}}
-    <div class="card">
-      <span class="lancer-header major">TAGS</span>
-      {{{tag-list "system.tags" system.tags editable}}}
-    </div>
-    
+    {{{item-edit-arrayed-tags "system.tags" "TAGS"}}}
   </div>
 
 </form>

--- a/public/templates/item/pilot_weapon.hbs
+++ b/public/templates/item/pilot_weapon.hbs
@@ -39,11 +39,7 @@
     {{{item-edit-arrayed-synergies    "system.synergies"      "SYNERGIES"}}}
 
     {{!-- Tags --}}
-    <div class="card full">
-      <span class="lancer-header major">TAGS</span>
-      {{{tag-list "system.tags" system.tags editable}}}
-    </div>
-
+    {{{item-edit-arrayed-tags "system.tags" "TAGS"}}}
   </div>
 
 </form>

--- a/public/templates/item/weapon_mod.hbs
+++ b/public/templates/item/weapon_mod.hbs
@@ -21,24 +21,18 @@
     <section class="sheet-body flexrow sheet-weapon-mod">
       <div class="flexcol" style="flex-basis: 66%">
         {{{item-edit-effect               "system.effect"}}}
-        {{{item-edit-arrayed-actions      "system.actions"        "ADDED ACTIONS"}}}
-        {{{item-edit-arrayed-damage       "system.added_damage"    "ADDED DAMAGE"}}}
-        {{{item-edit-arrayed-range        "system.added_range"     "ADDED RANGE"}}}
-        <div class="card full">
-          <span class="lancer-header submajor">ADDED TAGS</span>
-          {{{tag-list "system.added_tags" system.added_tags editable}}}
-        </div>
+        {{{item-edit-arrayed-actions      "system.actions"          "ADDED ACTIONS"}}}
+        {{{item-edit-arrayed-damage       "system.added_damage"     "ADDED DAMAGE"}}}
+        {{{item-edit-arrayed-range        "system.added_range"      "ADDED RANGE"}}}
+        {{{item-edit-arrayed-tags         "system.added_tags"       "ADDED TAGS"}}}
         {{{item-edit-arrayed-bonuses      "system.bonuses"}}}
         <div class="flexrow">
           {{{counter-array system.counters "system.counters" true}}}
         </div>
-        {{{item-edit-arrayed-deployables  "system.deployables"                "ADDED DEPLOYABLES"}}}
-        {{{item-edit-arrayed-synergies    "system.synergies"                  "SYNERGIES"}}}
-        {{{item-edit-arrayed-integrated   "system.integrated"                 "INTEGRATED ITEMS"}}}
-        <div class="card full">
-          <span class="lancer-header submajor">TAGS</span>
-          {{{tag-list "system.tags" system.tags editable}}}
-        </div>
+        {{{item-edit-arrayed-deployables  "system.deployables"      "ADDED DEPLOYABLES"}}}
+        {{{item-edit-arrayed-synergies    "system.synergies"        "SYNERGIES"}}}
+        {{{item-edit-arrayed-integrated   "system.integrated"       "INTEGRATED ITEMS"}}}
+        {{{item-edit-arrayed-tags         "system.tags"             "TAGS"}}}
       </div>
       <div class="flexcol" style="flex-basis: 33%;">
         {{{item-edit-license}}}

--- a/public/templates/window/tag.hbs
+++ b/public/templates/window/tag.hbs
@@ -4,9 +4,10 @@
 			<i class="${icon} i--m i--light header-icon"> </i>
 			<span class="major">TAG</span>
 		</div>
-		<div class="flexrow">
-			<label>LID: <input name="lid" value="{{ value.lid }}"/> </label>
-			<label>Value: <input class="lancer-stat" type="number" name="val" value="{{ value.val }}" data-dtype="Number" /></label>
+		<div class="flexrow flex-center">
+			{{{std-select "lid" lid_options label="LID: "}}}
+			<label for="val">Value: </label>
+			<input class="lancer-stat" type="number" name="val" value="{{ value.val }}" data-dtype="Number" />
 		</div>
 	</div>
 	{{> dialog-save-buttons}}

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -33,7 +33,7 @@ import { WeaponRangeTemplate } from "./module/pixi/weapon-range-template";
 // Import helpers
 import { preloadTemplates } from "./module/preload-templates";
 import { getAutomationOptions, registerSettings } from "./module/settings";
-import { compact_tag_list } from "./module/helpers/tags";
+import { compact_tag_list, itemEditTags } from "./module/helpers/tags";
 import * as migrations from "./module/world_migration";
 import { addLCPManager, updateCore, core_update } from "./module/apps/lcp-manager";
 
@@ -513,8 +513,8 @@ Hooks.once("init", async function () {
   // ------------------------------------------------------------------------
   // Tags
   // Handlebars.registerHelper("compact-tag", renderCompactTag);
-  // Handlebars.registerPartial("tag-list", compactTagList);
   Handlebars.registerHelper("tag-list", compact_tag_list);
+  Handlebars.registerHelper("item-edit-arrayed-tags", itemEditTags);
   // Handlebars.registerHelper("chunky-tag", renderChunkyTag);
   // Handlebars.registerHelper("full-tag", renderFullTag);
 

--- a/src/module/apps/tag-editor.ts
+++ b/src/module/apps/tag-editor.ts
@@ -1,4 +1,5 @@
-import { TagData } from "../models/bits/tag";
+import { LANCER } from "../config";
+import { TagData, TagTemplateData } from "../models/bits/tag";
 import { TargetedEditForm } from "./targeted-form-editor";
 
 /**
@@ -12,6 +13,16 @@ export class TagEditForm extends TargetedEditForm<TagData> {
       ...super.defaultOptions,
       template: `systems/${game.system.id}/templates/window/tag.hbs`,
       title: "Tag Editing",
+    };
+  }
+
+  getData() {
+    let tc = game.settings.get(game.system.id, LANCER.setting_tag_config) as Record<string, TagTemplateData>;
+    let lid_options = Object.values(tc).map(v => v.lid);
+    return {
+      ...super.getData(),
+      lid: super.getData().value.lid, // Compat thing for std-select
+      lid_options,
     };
   }
 }

--- a/src/module/helpers/commons.ts
+++ b/src/module/helpers/commons.ts
@@ -389,6 +389,23 @@ export function extendHelper(
   };
 }
 
+/**
+ * Use this when invoking a helper from outside a helper.
+ * A shitty hack that will break if handlebars partials are invoked
+ * @argument fake_data Will be used as the "data" for the hash
+ */
+export function spoofHelper(fake_data: any): HelperOptions {
+  let fail_callback = () => {
+    throw new Error("spoofHelper is not sufficient here.");
+  };
+  return {
+    fn: fail_callback,
+    inverse: fail_callback,
+    hash: {},
+    data: fake_data,
+  };
+}
+
 /** Enables controls that can (as specified by action):
  * - "delete": delete() the item located at data-path
  * - "null": set as null the value at the specified path

--- a/src/module/helpers/commons.ts
+++ b/src/module/helpers/commons.ts
@@ -566,6 +566,8 @@ async function control_structs(key: string): Promise<{ success: boolean; val: an
       return { success: true, val: defaults.ACTION() };
     case "counter":
       return { success: true, val: defaults.COUNTER() };
+    case "tag":
+      return { success: true, val: defaults.TAG() };
     case "bond_question":
       return { success: true, val: defaults.BOND_QUESTION() };
     case "power":
@@ -740,7 +742,7 @@ export function std_enum_select<T extends string>(path: string, enum_: { [key: s
         ${choices.join("")}
       </select>`;
   if (options.hash["label"]) {
-    return `<label class="flexrow no-wrap ${label_classes}">
+    return `<label class="flexrow flex-center no-wrap ${label_classes}">
       ${options.hash["label"]}
       ${select}
     </label>`;

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -13,6 +13,7 @@ import {
 } from "./npc";
 import { compact_tag_list } from "./tags";
 import {
+  array_path_edit_changes,
   defaultPlaceholder,
   drilldownDocument,
   effect_box,
@@ -1516,16 +1517,25 @@ function _handleContextMenus(
     },
   };
 
-  // Remove an array item (e.x. a counter or weapon profile)
+  // Remove an array item (e.x. a counter, tag, or weapon profile)
   let array_remove: ContextMenuEntry = {
     name: "Remove",
     icon: '<i class="fas fa-fw fa-trash"></i>',
-    callback: (html: JQuery) => {
+    callback: html => {
       // Find the counter
-      // let change = array_path_edit_changes(dd.sub_doc, dd.sub_path, null, "delete");
-      // dd.sub_doc.update({ [change.path]: change.new_val });
+      let dd_ = dd(html);
+      if (dd_) {
+        let change = array_path_edit_changes(dd_.sub_doc, dd_.sub_path, null, "delete");
+        dd_.sub_doc.update({ [change.path]: change.new_val });
+      }
     },
-    condition: () => !view_only && false, // TODO - fix so counters etc an be removed
+    condition: html => {
+      let p = path(html);
+      return !!(
+        !view_only &&
+        (p?.includes("tags") || p?.includes("counters") || p?.substring(0, p.length - 2).endsWith("profiles"))
+      );
+    },
   };
 
   // Summon counter editor dialogue

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -21,6 +21,7 @@ import {
   inc_if,
   resolve_dotpath,
   resolve_helper_dotpath,
+  spoofHelper,
   sp_display,
   std_enum_select,
   std_string_input,
@@ -406,7 +407,7 @@ export function pilot_armor_slot(armor_path: string, options: HelperOptions): st
             <div class="effect-text" style=" padding: 5px">
               ${armor.system.description}
             </div>
-            ${compact_tag_list(armor_path + ".system.tags", armor.system.tags, false)}
+            ${compact_tag_list(armor_path + ".system.tags", options)}
           </div>`;
 }
 
@@ -465,7 +466,7 @@ export function pilot_weapon_refview(weapon_path: string, options: HelperOptions
         ${inc_if(`</div>`, loading || limited)}
       </div>
 
-      ${compact_tag_list(weapon_path + ".system.tags", weapon.system.tags, false)}
+      ${compact_tag_list(weapon_path + ".system.tags", options)}
     </div>
   </div>`;
 }
@@ -511,7 +512,7 @@ export function pilot_gear_refview(gear_path: string, options: HelperOptions): s
         ${gear.system.description}
       </div>
 
-      ${compact_tag_list(gear_path + ".system.tags", gear.system.tags, false)}
+      ${compact_tag_list(gear_path + ".system.tags", options)}
     </div>
   </div>`;
 }
@@ -731,7 +732,7 @@ data-action="set" data-action-value="(int)${i}" data-path="${weapon_path}.system
           ${on_attack}
           ${on_hit}
           ${on_crit}
-          ${compact_tag_list(profile_path + ".tags", profile.tags, false)}
+          ${compact_tag_list(profile_path + ".tags", options)}
         </div>
         ${mod_text}
       </div>
@@ -783,11 +784,11 @@ export function weapon_mod_ref(mod_path: string, weapon_path: string | null, opt
     added_tags = `
     <div class="effect-box">
       <span class="effect-title clipped-bot">ADDED TAGS</span>
-      ${compact_tag_list(mod_path + ".system.added_tags", mod.system.added_tags, false)}
+      ${compact_tag_list(mod_path + ".system.added_tags", options)}
     </div>
     `;
   }
-  let tags = mod.system.tags.length ? compact_tag_list(`${mod_path}.system.tags`, mod.system.tags, false) : "";
+  let tags = mod.system.tags.length ? compact_tag_list(`${mod_path}.system.tags`, options) : "";
   let actions = "";
   if (mod.system.actions.length) {
     actions = buildActionArrayHTML(mod, "system.actions");
@@ -1020,7 +1021,7 @@ export function buildActionHTML(
   }
 
   if (options?.tags && doc instanceof LancerItem && doc.getTags()) {
-    tags = compact_tag_list("", doc.getTags()!, false);
+    tags = compact_tag_list("tags", spoofHelper({ tags: doc.getTags()! }));
   }
 
   return `
@@ -1190,7 +1191,7 @@ export function buildSystemHTML(system: LancerMECH_SYSTEM): string {
   ${eff ? eff : ""}
   ${actions ? actions : ""}
   ${deployables ? deployables : ""}
-  ${compact_tag_list("data.Tags", system.system.tags, false)}
+  ${compact_tag_list("tags", spoofHelper({ tags: system.getTags() }))}
 </div>`;
   return html;
 }

--- a/src/module/helpers/loadout.ts
+++ b/src/module/helpers/loadout.ts
@@ -1,7 +1,15 @@
 import type { HelperOptions } from "handlebars";
 import { ChipIcons, EntryType, SystemType } from "../enums";
 import { encodeMacroData } from "../macros";
-import { inc_if, resolve_helper_dotpath, array_path_edit, sp_display, effect_box, defaultPlaceholder } from "./commons";
+import {
+  inc_if,
+  resolve_helper_dotpath,
+  array_path_edit,
+  sp_display,
+  effect_box,
+  defaultPlaceholder,
+  spoofHelper,
+} from "./commons";
 import {
   mech_loadout_weapon_slot,
   buildActionHTML,
@@ -94,7 +102,7 @@ export function mech_system_view(system_path: string, options: HelperOptions): s
           ${eff ? eff : ""}
           ${actions ? actions : ""}
           ${deployables ? deployables : ""}
-          ${compact_tag_list(system_path + ".system.tags", doc.system.tags, false)}
+          ${compact_tag_list(system_path + ".system.tags", options)}
         </div>
         </li>`;
 }
@@ -261,9 +269,8 @@ export function frameView(frame_path: string, options: HelperOptions): string {
  */
 function buildCoreSysHTML(frame_path: string, options: HelperOptions): string {
   let frame = resolve_helper_dotpath<LancerFRAME>(options, frame_path)!;
-  let tags: string | undefined;
+  let tags = compact_tag_list(`${frame_path}.core_system.tags`, options);
   let core = frame.system.core_system;
-  tags = compact_tag_list("", core.tags, false);
 
   // Removing desc temporarily because of space constraints
   // <div class="frame-core-desc">${core.Description ? core.Description : ""}</div>
@@ -290,7 +297,7 @@ function buildCoreSysHTML(frame_path: string, options: HelperOptions): string {
       <div class="frame-active">${frame_active(frame_path, options)}</div>
       ${passive}
       ${deployables}
-      ${tags ? tags : ""}
+      ${tags}
     </div>
   </div>`;
 }

--- a/src/module/helpers/npc.ts
+++ b/src/module/helpers/npc.ts
@@ -107,7 +107,7 @@ export function npc_reaction_effect_preview(path: string, options: HelperOptions
       }
       ${effect_box("TRIGGER", (npc_feature.system as SystemTemplates.NPC.ReactionData).trigger)}
       ${effect_box("EFFECT", npc_feature.system.effect)}
-      ${compact_tag_list(path + ".system.tags", npc_feature.system.tags, false)}
+      ${compact_tag_list(path + ".system.tags", options)}
     </div>`,
     options
   );
@@ -128,7 +128,7 @@ function npc_system_trait_effect_preview(path: string, options: HelperOptions): 
           : ""
       }
       ${effect_box("EFFECT", npc_feature.system.effect)}
-      ${compact_tag_list(path + ".system.tags", npc_feature.system.tags, false)}
+      ${compact_tag_list(path + ".system.tags", options)}
     </div>`,
     options
   );
@@ -185,7 +185,7 @@ export function npc_tech_effect_preview(path: string, options: HelperOptions) {
       </div>
       <div class="flexcol" style="padding: 0 10px;">
         ${effect_box("EFFECT", feature_data.effect)}
-        ${compact_tag_list(path + ".system.tags", npc_feature.system.tags, false)}
+        ${compact_tag_list(path + ".system.tags", options)}
       </div>
     </div>
     `,
@@ -247,7 +247,7 @@ export function npc_weapon_effect_preview(path: string, options: HelperOptions):
       </div>
       ${effect_box("ON HIT", feature_data.on_hit)}
       ${effect_box("EFFECT", feature_data.effect)}
-      ${compact_tag_list(path + ".system.tags", feature_data.tags, false)}
+      ${compact_tag_list(path + ".system.tags", options)}
     </div>
     `,
     options

--- a/src/module/helpers/tags.ts
+++ b/src/module/helpers/tags.ts
@@ -1,5 +1,6 @@
-import type { LancerActorSheetData, LancerItemSheetData } from "../interfaces";
-import { Tag } from "../models/bits/tag";
+import type { HelperOptions } from "handlebars";
+import { Tag, TagData } from "../models/bits/tag";
+import { inc_if, resolve_helper_dotpath } from "./commons";
 
 // A small tag display containing just the label and value
 export function compact_tag(tag_path: string, tag: Tag): string {
@@ -12,8 +13,9 @@ export function compact_tag(tag_path: string, tag: Tag): string {
 }
 
 // The above, but on an array, filtering out hidden as appropriate
-export function compact_tag_list(tag_array_path: string, tags: Tag[], allow_drop: boolean): string {
+export function compact_tag_list(tag_array_path: string, options: HelperOptions): string {
   // Collect all of the tags, formatting them using `compact_tag`
+  let tags = resolve_helper_dotpath<Tag[]>(options, tag_array_path) ?? [];
   let processed_tags: string[] = [];
   for (let i = 0; i < tags.length; i++) {
     let tag = tags[i];
@@ -25,7 +27,7 @@ export function compact_tag_list(tag_array_path: string, tags: Tag[], allow_drop
   }
 
   // Combine into a row
-  if (allow_drop) {
+  if (resolve_helper_dotpath(options, "editable", false, true)) {
     return `<div class="compact-tag-row tag-list-append" data-path="${tag_array_path}">
       ${processed_tags.join("")}
     </div>`;
@@ -36,6 +38,21 @@ export function compact_tag_list(tag_array_path: string, tags: Tag[], allow_drop
   } else {
     return "";
   }
+}
+
+// A card with tags in it, that allows editing if appropriate
+export function itemEditTags(path: string, header: string, options: HelperOptions) {
+  return `
+  <div class="card full">
+    <div class="lancer-header major">
+      <span>${header}</span>
+      ${inc_if(
+        `<a class="gen-control fas fa-plus" data-action="append" data-path="${path}" data-action-value="(struct)tag"></a>`,
+        resolve_helper_dotpath(options, "editable", false, true)
+      )}
+    </div>
+    ${compact_tag_list(path, options)}
+  </div>`;
 }
 
 // Enables dropping of tags into open designated by .ref-list classed divs

--- a/src/module/util/unpacking/defaults.ts
+++ b/src/module/util/unpacking/defaults.ts
@@ -18,6 +18,7 @@ import { CounterData } from "../../models/bits/counter";
 import { SystemTemplates } from "../../system-template";
 import { PowerData } from "../../models/bits/power";
 import { BondQuestionData } from "../../models/bits/question";
+import { TagData } from "../../models/bits/tag";
 
 const DEFAULT_DESCRIPTION = "";
 
@@ -94,6 +95,13 @@ export function COUNTER(): CounterData {
     max: 6,
     default_value: 1,
     value: 1,
+  };
+}
+
+export function TAG(): TagData {
+  return {
+    lid: "tg_unknown",
+    val: "",
   };
 }
 


### PR DESCRIPTION
Fixed tags not being addable now thata they aren't an item.
- Tags now addable via a + on tag card on an item
- This will make a blank tag, which can be edited / removed via the right click context menu
- Also streamlined the compact tag helper while i was at it.