### PR TITLE
Add lancer-initiative to the source tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "fp-ts": "^2.11.2",
         "io-ts": "^2.2.16",
         "jszip": "^3.10.1",
-        "lancer-initiative": "^3.1.0",
         "marked": "^4.0.10",
         "tippy.js": "^6.3.1"
       },
@@ -15893,10 +15892,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/lancer-initiative": {
-      "version": "3.1.0",
-      "license": "Apache-2.0"
     },
     "node_modules/last-run": {
       "version": "1.1.1",
@@ -35542,9 +35537,6 @@
     "kleur": {
       "version": "4.1.4",
       "dev": true
-    },
-    "lancer-initiative": {
-      "version": "3.1.0"
     },
     "last-run": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "fp-ts": "^2.11.2",
     "io-ts": "^2.2.16",
     "jszip": "^3.10.1",
-    "lancer-initiative": "^3.1.0",
     "marked": "^4.0.10",
     "tippy.js": "^6.3.1"
   },

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,53 @@
-import type { LancerInitiativeConfig } from "lancer-initiative";
 import type { AutomationOptions } from "./module/settings";
 import type { LancerActionManager } from "./module/action/action-manager";
+
+interface LancerInitiativeConfig<T extends string = string> {
+  /**
+   * Namespace for flags and settings. Should be the id of the system or
+   * module.
+   */
+  module: T;
+  /**
+   * Filepath to the handlebars template for LancerCombatTracker. Can be
+   * omitted if LancerCombatTracker is not used.
+   */
+  templatePath?: string;
+  /**
+   * Default appearance settings for LancerCombatTracker. Can be omitted if
+   * LancerCombatTracker is not used.
+   */
+  def_appearance?: {
+    icon: string;
+    icon_size: number;
+    player_color: string;
+    friendly_color: string;
+    neutral_color: string;
+    enemy_color: string;
+    done_color: string;
+  };
+  /**
+   * Activations for each unit.  If a string, path to the activation parameter
+   * in actor.getRollData(), if a number, that value. Otherwise 1
+   * @defaultValue `1`
+   */
+  activations?: string | number;
+  /**
+   * Whether to enable the initiative rolling buttons in the tracker. Only
+   * needed if LancerCombatTracker or a subclass is used for the tracker and
+   * intitaitve rolling is wanted.
+   * @defaultValue `false`
+   */
+  enable_initiative?: boolean;
+  /**
+   * Whether to sort the displayed combat tracker based on activation status.
+   * If enabled, the active unit is displayed on the top and units that have
+   * used all their activations are sorted to the bottom. Only needed if
+   * LancerCombatTracker or a subclass is used and sorting is not wanted, or
+   * the ability to toggle it is desired.
+   * @defaultValue `true`
+   */
+  sort?: boolean;
+}
 
 declare global {
   // Since we never use these before `init` tell league types that they are

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -146,7 +146,8 @@ import { LancerToken, LancerTokenDocument } from "./module/token";
 import { applyGlobalDragListeners } from "./module/helpers/dragdrop";
 import { gridDist } from "./module/helpers/automation/targeting";
 import CompconLoginForm from "./module/helpers/compcon-login-form";
-import { LancerCombat, LancerCombatant, LancerCombatTracker } from "lancer-initiative";
+import { LancerCombat, LancerCombatant } from "./module/combat/lancer-combat";
+import { LancerCombatTracker } from "./module/combat/lancer-combat-tracker";
 import { LancerCombatTrackerConfig } from "./module/helpers/lancer-initiative-config-form";
 import { MechModel } from "./module/models/actors/mech";
 import { MechSystemModel } from "./module/models/items/mech_system";
@@ -313,7 +314,6 @@ Hooks.once("init", async function () {
   CONFIG.Token.objectClass = LancerToken;
   CONFIG.Combat.documentClass = LancerCombat;
   CONFIG.Combatant.documentClass = LancerCombatant;
-  // @ts-expect-error TODO: fix up Options vs ApplicationOptions once we have more modern types
   CONFIG.ui.combat = LancerCombatTracker;
 
   // Set up default system status icons

--- a/src/module/combat/lancer-combat-tracker.ts
+++ b/src/module/combat/lancer-combat-tracker.ts
@@ -1,0 +1,189 @@
+import type { LancerCombat, LancerCombatant } from "./lancer-combat.js";
+
+/**
+ * Overrides the display of the combat and turn order tab to add activation
+ * buttons and either move or remove the initiative button
+ */
+export class LancerCombatTracker extends CombatTracker {
+  static override get defaultOptions(): CombatTracker.Options {
+    return {
+      ...super.defaultOptions,
+      template: CONFIG.LancerInitiative.templatePath!,
+    };
+  }
+
+  override scrollToTurn(): void {
+    if (this.viewed?.turn == null || !(CONFIG.LancerInitiative?.sort ?? true)) return super.scrollToTurn();
+    this.element.find("ol#combat-tracker")[0].scrollTop = 0;
+  }
+
+  /**
+   * Intercepts the data being sent to the combat tracker window and
+   * optionally sorts the the turn data that gets displayed. This allows the
+   * units that have already gone to be moved to the bottom without the risk of
+   * updateCombat events being eaten.
+   */
+  override async getData(options?: Partial<CombatTracker.Options>): Promise<CombatTracker.Data> {
+    const config = CONFIG.LancerInitiative;
+    const appearance = getTrackerAppearance();
+    const data = (await super.getData(options)) as {
+      turns: {
+        id: string;
+        css: string;
+        pending: number;
+        finished: number;
+      }[];
+      [x: string]: unknown;
+    };
+    const sort = config.sort ?? true;
+    const disp: Record<number, string> = {
+      [-2]: "",
+      [-1]: "enemy",
+      [0]: "neutral",
+      [1]: "friendly",
+      [2]: "player",
+    };
+    data.turns = data.turns.map(t => {
+      const combatant: LancerCombatant | undefined = <LancerCombatant>(
+        this.viewed!.getEmbeddedDocument("Combatant", t.id)
+      );
+      return {
+        ...t,
+        css: t.css + " " + disp[combatant?.disposition ?? -2],
+        pending: combatant?.activations.value ?? 0,
+        finished: (combatant?.activations.max ?? 1) - (combatant?.activations.value ?? 0),
+      };
+    });
+    if (sort) {
+      data.turns.sort(function (a, b) {
+        const aa = a.css.indexOf("active") !== -1 ? 1 : 0;
+        const ba = b.css.indexOf("active") !== -1 ? 1 : 0;
+        if (ba - aa !== 0) return ba - aa;
+        const ad = a.pending === 0 ? 1 : 0;
+        const bd = b.pending === 0 ? 1 : 0;
+        return ad - bd;
+      });
+    }
+    data.icon_class = appearance.icon;
+    data.enable_initiative = CONFIG.LancerInitiative.enable_initiative ?? false;
+    return <CombatTracker.Data>data;
+  }
+
+  override activateListeners(html: JQuery<HTMLElement>): void {
+    super.activateListeners(html);
+    html.find(".lancer-combat-control").on("click", this._onActivateCombatant.bind(this));
+  }
+
+  /**
+   * Activate the selected combatant
+   */
+  protected async _onActivateCombatant(
+    event: JQuery.ClickEvent<HTMLElement, undefined, HTMLElement, HTMLElement>
+  ): Promise<void> {
+    event.preventDefault();
+    event.stopPropagation();
+    const btn = event.currentTarget;
+    const id = btn.closest<HTMLElement>(".combatant")?.dataset.combatantId;
+    if (!id) return;
+    switch (btn.dataset.control) {
+      case "deactivateCombatant":
+        await (<LancerCombat>this.viewed!).deactivateCombatant(id);
+        break;
+      case "activateCombatant":
+        await (<LancerCombat>this.viewed!).activateCombatant(id);
+        break;
+    }
+  }
+
+  protected async _onAddActivation(li: JQuery<HTMLElement>): Promise<void> {
+    const combatant: LancerCombatant = <LancerCombatant>(
+      this.viewed!.getEmbeddedDocument("Combatant", li.data("combatant-id"))
+    );
+    await combatant.addActivations(1);
+  }
+
+  protected async _onRemoveActivation(li: JQuery<HTMLElement>): Promise<void> {
+    const combatant: LancerCombatant = <LancerCombatant>(
+      this.viewed!.getEmbeddedDocument("Combatant", li.data("combatant-id"))
+    );
+    await combatant.addActivations(-1);
+  }
+
+  protected async _onUndoActivation(li: JQuery<HTMLElement>): Promise<void> {
+    const combatant: LancerCombatant = <LancerCombatant>(
+      this.viewed!.getEmbeddedDocument("Combatant", li.data("combatant-id"))
+    );
+    await combatant.modifyCurrentActivations(1);
+  }
+
+  protected override _getEntryContextOptions(): ContextMenuEntry[] {
+    const m: ContextMenuEntry[] = [
+      {
+        name: "LANCERINITIATIVE.AddActivation",
+        icon: '<i class="fas fa-plus"></i>',
+        callback: this._onAddActivation.bind(this),
+      },
+      {
+        name: "LANCERINITIATIVE.RemoveActivation",
+        icon: '<i class="fas fa-minus"></i>',
+        callback: this._onRemoveActivation.bind(this),
+      },
+      {
+        name: "LANCERINITIATIVE.UndoActivation",
+        icon: '<i class="fas fa-undo"></i>',
+        callback: this._onUndoActivation.bind(this),
+      },
+    ];
+    m.push(...super._getEntryContextOptions().filter(i => i.name !== "COMBAT.CombatantReroll"));
+    return m;
+  }
+}
+
+/**
+ * Get the current appearance data from settings
+ */
+export function getTrackerAppearance(): NonNullable<CONFIG["LancerInitiative"]["def_appearance"]> {
+  const config = CONFIG.LancerInitiative;
+  if (!config.def_appearance) throw new Error("No default appearance specified in CONFIG.LancerInitiative");
+  return {
+    ...config.def_appearance,
+    ...(game.settings.get(config.module, "combat-tracker-appearance") as Appearance),
+  };
+}
+
+export function setAppearance(val: Partial<Appearance>): void {
+  const defaults = CONFIG.LancerInitiative.def_appearance!;
+  document.documentElement.style.setProperty(
+    "--lancer-initiative-icon-size",
+    `${val?.icon_size ?? defaults.icon_size}rem`
+  );
+  document.documentElement.style.setProperty(
+    "--lancer-initiative-player-color",
+    val?.player_color ?? defaults.player_color
+  );
+  document.documentElement.style.setProperty(
+    "--lancer-initiative-friendly-color",
+    val?.friendly_color ?? defaults.friendly_color
+  );
+  document.documentElement.style.setProperty(
+    "--lancer-initiative-neutral-color",
+    val?.neutral_color ?? defaults.neutral_color
+  );
+  document.documentElement.style.setProperty(
+    "--lancer-initiative-enemy-color",
+    val?.enemy_color ?? defaults.enemy_color
+  );
+  document.documentElement.style.setProperty("--lancer-initiative-done-color", val?.done_color ?? defaults.done_color);
+  game.combats?.render();
+}
+
+type Appearance = Partial<CONFIG["LancerInitiative"]["def_appearance"]>;
+
+/**
+ * Register the helper we use to print the icon the correnct number of times
+ */
+Handlebars.registerHelper("lancerinitiative-repeat", function (n, block) {
+  let accum = "";
+  for (let i = 0; i < n; i++) accum += block.fn(i);
+  return accum;
+});

--- a/src/module/combat/lancer-combat.ts
+++ b/src/module/combat/lancer-combat.ts
@@ -1,0 +1,211 @@
+/**
+ * Overrides and extends the Combat class to use an activation model instead of
+ * the standard ordered list of turns. {@link LancerCombat#activateCombatant}
+ * is added to the interface.
+ */
+export class LancerCombat extends Combat {
+  protected override _sortCombatants(a: LancerCombatant, b: LancerCombatant): number {
+    // Sort by Players then Neutrals then Hostiles
+    const dc = b.disposition - a.disposition;
+    if (dc !== 0) return dc;
+    return super._sortCombatants(a, b);
+  }
+
+  protected override async _preCreate(...[data, options, user]: Parameters<Combat["_preCreate"]>): Promise<void> {
+    // @ts-expect-error v10
+    this.updateSource({ turn: null });
+    return super._preCreate(data, options, user);
+  }
+
+  /**
+   * Set all combatants to their max activations
+   */
+  async resetActivations(): Promise<LancerCombatant[]> {
+    const module = CONFIG.LancerInitiative.module;
+    const skipDefeated = "skipDefeated" in this.settings && this.settings.skipDefeated;
+    const updates = this.combatants.map(c => {
+      return {
+        _id: c.id,
+        [`flags.${module}.activations.value`]:
+          // @ts-expect-error V10 typings
+          skipDefeated && c.isDefeated ? 0 : (<LancerCombatant>c).activations.max ?? 0,
+      };
+    });
+    return <Promise<LancerCombatant[]>>this.updateEmbeddedDocuments("Combatant", updates);
+  }
+
+  override async startCombat(): Promise<this | undefined> {
+    await this.resetActivations();
+    return this.update({ round: 1, turn: null });
+  }
+
+  override async nextRound(): Promise<this | undefined> {
+    await this.resetActivations();
+    let advanceTime = Math.max(this.turns.length - (this.turn || 0), 0) * CONFIG.time.turnTime;
+    advanceTime += CONFIG.time.roundTime;
+    // @ts-ignore jtfc advanceTime is fucking used in foundry.js
+    return this.update({ round: this.round + 1, turn: null }, { advanceTime });
+  }
+
+  /**
+   * Ends the current turn without starting a new one
+   */
+  override async nextTurn(): Promise<this | undefined> {
+    return this.update({ turn: null });
+  }
+
+  override async previousRound(): Promise<this | undefined> {
+    await this.resetActivations();
+    const round = Math.max(this.round - 1, 0);
+    let advanceTime = 0;
+    if (round > 0) advanceTime -= CONFIG.time.roundTime;
+    // @ts-ignore jtfc advanceTime is fucking used in foundry.js
+    return this.update({ round, turn: null }, { advanceTime });
+  }
+
+  override async resetAll(): Promise<this | undefined> {
+    await this.resetActivations();
+    // @ts-expect-error V10 typings
+    this.combatants.forEach(c => c.updateSource({ initiative: null }));
+    return this.update({ turn: null, combatants: this.combatants.toObject() }, { diff: false });
+  }
+
+  /**
+   * Sets the active turn to the combatant passed by id or calls
+   * {@link LancerCombat#requestActivation()} if the user does not have
+   * permission to modify the combat
+   */
+  async activateCombatant(id: string, override = false): Promise<this | undefined> {
+    if (!game.user?.isGM && !override) return this.requestActivation(id);
+    const combatant = <LancerCombatant | undefined>this.getEmbeddedDocument("Combatant", id);
+    if (!combatant?.activations.value) return this;
+    await combatant?.modifyCurrentActivations(-1);
+    const turn = this.turns.findIndex(t => t.id === id);
+    return this.update({ turn });
+  }
+
+  /**
+   * Sets the active turn back to 0 (no active unit) if the passed id
+   * corresponds to the current turn and the user has ownership of the
+   * combatant.
+   */
+  async deactivateCombatant(id: string) {
+    const turn = this.turns.findIndex(t => t.id === id);
+    if (turn !== this.turn) return this;
+    if (!this.turns[turn].testUserPermission(game.user!, "OWNER") && !game.user?.isGM) return this;
+    return this.nextTurn();
+  }
+
+  /**
+   * Calls any Hooks registered for "LancerCombatRequestActivate".
+   */
+  protected async requestActivation(id: string): Promise<this> {
+    Hooks.callAll("LancerCombatRequestActivate", this, id);
+    return this;
+  }
+}
+
+export class LancerCombatant extends Combatant {
+  /**
+   * This just fixes a bug in foundry 0.8.x that prevents Combatants with no
+   * associated token or actor from being modified, even by the GM
+   */
+  override testUserPermission(...[user, permission, options]: Parameters<Combatant["testUserPermission"]>): boolean {
+    return this.actor?.testUserPermission(user, permission, options) ?? user.isGM;
+  }
+
+  override prepareBaseData(): void {
+    super.prepareBaseData();
+    const module = CONFIG.LancerInitiative.module;
+    if (
+      // @ts-expect-error
+      this.flags?.[module]?.activations?.max === undefined &&
+      canvas?.ready
+    ) {
+      let activations: number;
+      switch (typeof CONFIG.LancerInitiative.activations) {
+        case "string":
+          activations =
+            foundry.utils.getProperty(this.actor?.getRollData() ?? {}, CONFIG.LancerInitiative.activations) ?? 1;
+          break;
+        case "number":
+          activations = CONFIG.LancerInitiative.activations;
+          break;
+        default:
+          activations = 1;
+          break;
+      }
+      // @ts-expect-error v10
+      this.updateSource({
+        [`flags.${module}.activations`]: {
+          max: activations,
+          value: (this.parent?.round ?? 0) > 0 ? activations : 0,
+        },
+      });
+    }
+  }
+
+  /**
+   * The current activation data for the combatant.
+   */
+  get activations(): Activations {
+    const module = CONFIG.LancerInitiative.module;
+    return <Activations>this.getFlag(module, "activations") ?? {};
+  }
+
+  /**
+   * The disposition for this combatant. In order, manually specified for this
+   * combatant, token dispostion, token disposition for the associated actor,
+   * -2.
+   */
+  get disposition(): number {
+    const module = CONFIG.LancerInitiative.module;
+    return (
+      <number>this.getFlag(module, "disposition") ??
+      (this.actor?.hasPlayerOwner ?? false
+        ? 2
+        : // @ts-expect-error v10
+          this.token?.disposition ??
+          // @ts-expect-error v10
+          this.actor?.prototypeToken.disposition ??
+          -2)
+    );
+  }
+
+  /**
+   * Adjusts the number of activations that a combatant can take
+   * @param num - The number of maximum activations to add (can be negative)
+   */
+  async addActivations(num: number): Promise<this | undefined> {
+    const module = CONFIG.LancerInitiative.module;
+    if (num === 0) return this;
+    return this.update({
+      [`flags.${module}.activations`]: {
+        max: Math.max((this.activations.max ?? 1) + num, 1),
+        value: Math.max((this.activations.value ?? 0) + num, 0),
+      },
+    });
+  }
+
+  /**
+   * Adjusts the number of current activations that a combatant has
+   * @param num - The number of current activations to add (can be negative)
+   */
+  async modifyCurrentActivations(num: number): Promise<this | undefined> {
+    const module = CONFIG.LancerInitiative.module;
+    if (num === 0) return this;
+    return this.update({
+      [`flags.${module}.activations`]: {
+        value: Math.clamped((this.activations?.value ?? 0) + num, 0, this.activations?.max ?? 1),
+      },
+    });
+  }
+}
+
+/**
+ * Interface for the activations object
+ */
+interface Activations {
+  max?: number;
+  value?: number;
+}

--- a/src/module/helpers/automation/combat.ts
+++ b/src/module/helpers/automation/combat.ts
@@ -1,4 +1,4 @@
-import { LancerCombat } from "lancer-initiative";
+import { LancerCombat } from "../../combat/lancer-combat";
 import { modAction } from "../../action/action-tracker";
 import { LancerActor } from "../../actor/lancer-actor";
 import { prepareChargeMacro } from "../../macros";

--- a/src/module/helpers/combat-carousel.ts
+++ b/src/module/helpers/combat-carousel.ts
@@ -1,4 +1,4 @@
-import type { LancerCombat, LancerCombatant } from "lancer-initiative";
+import type { LancerCombat, LancerCombatant } from "../combat/lancer-combat";
 import { LancerCombatTrackerConfig } from "./lancer-initiative-config-form";
 
 const dispositions: Record<number, string> = {

--- a/src/module/helpers/lancer-initiative-config-form.ts
+++ b/src/module/helpers/lancer-initiative-config-form.ts
@@ -1,4 +1,4 @@
-import { getTrackerAppearance } from "lancer-initiative";
+import { getTrackerAppearance } from "../combat/lancer-combat-tracker";
 type Appearance = NonNullable<typeof CONFIG.LancerInitiative.def_appearance>;
 
 export class LancerCombatTrackerConfig extends CombatTrackerConfig<

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -1,5 +1,5 @@
-import { getTrackerAppearance, setAppearance } from "lancer-initiative";
-import type { LancerCombat, LancerCombatant } from "lancer-initiative";
+import { getTrackerAppearance, setAppearance } from "./combat/lancer-combat-tracker";
+import type { LancerCombat, LancerCombatant } from "./combat/lancer-combat";
 import { LANCER } from "./config";
 import { AutomationConfig } from "./apps/automation-settings";
 import CompconLoginForm from "./helpers/compcon-login-form";


### PR DESCRIPTION
This moves the combat tracker customizations from a node module to exist in tree, since the module is being discontinued (or rewritten maybe).