### PR TITLE
Add height and width parameters to intangible svg

### DIFF
--- a/public/assets/icons/status_intangible.svg
+++ b/public/assets/icons/status_intangible.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg version="1.1" viewBox="0 0 1080 1080" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<svg height="512" width="512" version="1.1" viewBox="0 0 1080 1080" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 <metadata>
 <rdf:RDF>
 <cc:Work rdf:about="">

--- a/public/assets/icons/white/status_intangible.svg
+++ b/public/assets/icons/white/status_intangible.svg
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   height="512"
+   width="512"
    version="1.1"
    viewBox="0 0 1080 1080"
    id="svg8"


### PR DESCRIPTION
If these aren't present, setting up the canvas halts on firefox while setting up the status icons due to a PIXI.js bug.

https://github.com/pixijs/pixijs/issues/7877