### PR TITLE
Update system file to allow system to be used in v11

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -7,8 +7,8 @@
   "minimumCoreVersion": "10",
   "compatibility": {
     "minimum": 10,
-    "verified": "10.303",
-    "maximum": 10
+    "verified": "11.315",
+    "maximum": 11
   },
   "authors": [
     {"name": "Eranziel"},


### PR DESCRIPTION
I tested this system in  foundry version 11.315 and didn't see any immediate issues. I updated the system file so that it can now show up in the systems list in v11 too.