### PR TITLE
Add automation setting for token size

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -220,7 +220,9 @@
       "remove_templates": "Remove Templates Each Turn",
       "remove_templates-desc": "When the turn changes, should measured templates from attacks be cleared?",
       "limited_loading": "Manage Limited/Loading",
-      "limited_loading-desc": "When items are used, should their limited and loading status be automatically managed and tracked?"
+      "limited_loading-desc": "When items are used, should their limited and loading status be automatically managed and tracked?",
+      "token_size": "Manage Token Sizes",
+      "token_size-desc": "Automatically force tokens sizes to match the associated actor's size stat."
     },
     "actionTracker": {
       "menu-name": "Action Tracker",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -267,6 +267,12 @@
       "pilot-items": "Pilot Items",
       "player-actors": "Premade Player Actors",
       "status-items": "Status/Condition"
+    },
+    "tokenConfig": {
+      "manual_token_size": {
+        "label": "Manual Token Sizing",
+        "hint": "Bypass system automation for determining token size"
+      }
     }
   },
   "LANCERINITIATIVE": {

--- a/public/templates/window/automation-config.hbs
+++ b/public/templates/window/automation-config.hbs
@@ -72,6 +72,17 @@
     <p class="notes">{{ localize "lancer.automation.remove_templates-desc" }}</p>
   </div>
   <div class="form-group">
+    <label>{{ localize "lancer.automation.token_size" }}</label>
+    <input
+        type="checkbox"
+        name="token_size"
+        {{#if token_size}}checked{{/if}}
+        {{#unless enabled}}disabled{{/unless}}
+        data-dtype="Boolean"
+    />
+    <p class="notes">{{ localize "lancer.automation.token_size-desc" }}</p>
+  </div>
+  <div class="form-group">
     <button type="submit" name="submit">
       <i class="fas fa-save"></i>
       <span>Save</span>

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -144,7 +144,7 @@ import { applyCollapseListeners, initializeCollapses } from "./module/helpers/co
 import { handleCombatUpdate } from "./module/helpers/automation/combat";
 import { handleActorExport, validForExport } from "./module/helpers/io";
 import { runEncodedMacro } from "./module/macros";
-import { LancerToken, LancerTokenDocument } from "./module/token";
+import { extendTokenConfig, LancerToken, LancerTokenDocument } from "./module/token";
 import { applyGlobalDragListeners } from "./module/helpers/dragdrop";
 import { gridDist } from "./module/helpers/automation/targeting";
 import CompconLoginForm from "./module/helpers/compcon-login-form";
@@ -662,6 +662,9 @@ Hooks.once("init", async function () {
   // });
 
   Hooks.on("renderCombatCarousel", handleRenderCombatCarousel);
+
+  // Extend TokenConfig for token size automation
+  Hooks.on("renderTokenConfig", extendTokenConfig);
 });
 
 /* ------------------------------------ */

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -528,26 +528,6 @@ export class LancerActor extends Actor {
         this.beginStructureFlow();
       }
     }
-
-    // If the Size of the ent has changed since the last update, set the
-    // protype token size to the new size
-    const expected_size = Math.max(1, this.system.size);
-    // Update either prototype token or the token itself depending
-    // @ts-expect-error prototypeToken is not in the types
-    const token = this.token ?? this.prototypeToken;
-    if (token && token.width !== expected_size) {
-      token.update({
-        width: expected_size,
-        height: expected_size,
-        flags: {
-          "hex-size-support": {
-            borderSize: expected_size,
-            altSnapping: true,
-            evenSnap: !(expected_size % 2),
-          },
-        },
-      });
-    }
   }
 
   /** @inheritdoc

--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -657,6 +657,23 @@ export class LancerActor extends Actor {
     });
   }
 
+  /**
+   * Taking a new frame/class, set the prototype token size
+   * @param newFrame - The new frame or class to pull the size from.
+   */
+  async updateTokenSize(newFrame: LancerFRAME | LancerNPC_CLASS): Promise<void> {
+    let new_size: number | undefined;
+    if (newFrame.is_frame() && this.is_mech()) {
+      new_size = Math.max(1, newFrame.system.stats.size);
+    } else if (newFrame.is_npc_class() && this.is_npc()) {
+      const tier = this.system.tier || 1;
+      new_size = Math.max(1, newFrame.system.base_stats[tier - 1].size);
+    }
+    if (!new_size) return;
+    // @ts-expect-error
+    await this.prototypeToken.update({ height: new_size, width: new_size });
+  }
+
   // Checks that the provided document is not null, and is a lancer actor
   static async fromUuid(x: string | LancerActor, messagePrefix?: string): Promise<LancerActor> {
     if (x instanceof LancerActor) return x;

--- a/src/module/actor/mech-sheet.ts
+++ b/src/module/actor/mech-sheet.ts
@@ -70,6 +70,7 @@ export class LancerMechSheet extends LancerActorSheet<EntryType.MECH> {
     if (drop.type == "Item" && drop.document.is_frame() && this.actor.is_mech()) {
       // If new frame, auto swap with prior frame
       await this.actor.swapFrameImage(drop.document);
+      await this.actor.updateTokenSize(drop.document);
       await this.actor.update({
         "system.loadout.frame": drop.document.id,
       });

--- a/src/module/actor/npc-sheet.ts
+++ b/src/module/actor/npc-sheet.ts
@@ -149,6 +149,7 @@ export class LancerNPCSheet extends LancerActorSheet<EntryType.NPC> {
       }
       if (doc.is_npc_class()) {
         await this.actor.swapFrameImage(doc);
+        await this.actor.updateTokenSize(doc);
       }
     }
 

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -205,6 +205,7 @@ export function getAutomationOptions(useDefault = false): AutomationOptions {
     attack_self_heat: true,
     limited_loading: true,
     remove_templates: false,
+    token_size: true,
   };
   if (useDefault) return def;
   const settings = (game.settings.get(game.system.id, LANCER.setting_automation) as Record<string, boolean>) ?? {};
@@ -223,6 +224,7 @@ export function getAutomationOptions(useDefault = false): AutomationOptions {
       attack_self_heat: false,
       limited_loading: false,
       remove_templates: false,
+      token_size: false,
     };
   }
 }
@@ -269,6 +271,11 @@ export interface AutomationOptions {
    * @defaultValue `false`
    */
   remove_templates: boolean;
+  /**
+   * Automatically manage token sizes based on the actor
+   * @defaultValue `true`
+   */
+  token_size: boolean;
 }
 
 //

--- a/src/module/token.ts
+++ b/src/module/token.ts
@@ -39,7 +39,7 @@ export class LancerTokenDocument extends TokenDocument {
   }
 
   async _preCreate(...[data, options, user]: Parameters<TokenDocument["_preCreate"]>) {
-    if (getAutomationOptions().token_size && !this.actor?.getFlag(game.system.id, "manual_token_size")) {
+    if (getAutomationOptions().token_size && !this.getFlag(game.system.id, "manual_token_size")) {
       const new_size = Math.max(1, this.actor?.system.size ?? 1);
       // @ts-expect-error v10
       this.updateSource({ width: new_size, height: new_size });
@@ -51,7 +51,7 @@ export class LancerTokenDocument extends TokenDocument {
     // @ts-expect-error
     super._onRelatedUpdate(update, options);
 
-    if ((getAutomationOptions().token_size && !game.system.id, "manual_token_size")) {
+    if (getAutomationOptions().token_size && !this.getFlag(game.system.id, "manual_token_size")) {
       let new_size = this.actor?.system.size;
       if (new_size !== undefined) this.update({ width: Math.max(1, new_size), height: Math.max(1, new_size) });
     }
@@ -120,6 +120,32 @@ export class LancerToken extends Token {
     // Make a clone so the cache can't be mutated
     return this._spaces.spaces.map(p => ({ ...p }));
   }
+}
+
+export function extendTokenConfig(...[app, html, _data]: Parameters<Hooks.RenderApplication<TokenConfig>>) {
+  const auto = getAutomationOptions().token_size;
+  if (!auto) return;
+  const manual = (app.object.getFlag(game.system.id, "manual_token_size") ?? false) as boolean;
+  html.find("[name=width]").closest(".form-group").before(`
+    <div class="form-group slim">
+      <label>${game.i18n.localize("lancer.tokenConfig.manual_token_size.label")}</label>
+      <div class="form-fields">
+        <input type="checkbox"
+          name="flags.${game.system.id}.manual_token_size"
+          ${manual ? "checked" : ""}
+        >
+      </div>
+      <p class="hint">${game.i18n.localize("lancer.tokenConfig.manual_token_size.hint")}</p>
+    </div>`);
+  const toggle_inputs = (ev: JQuery.ChangeEvent<HTMLElement, undefined, HTMLElement, HTMLInputElement>) => {
+    const checked = ev.target.checked;
+    html.find("[name=width]").prop("disabled", !checked);
+    html.find("[name=height]").prop("disabled", !checked);
+  };
+  html.find(`[name='flags.${game.system.id}.manual_token_size']`).on("change" as any, toggle_inputs);
+  html.find("[name=width]").prop("disabled", !manual);
+  html.find("[name=height]").prop("disabled", !manual);
+  app.setPosition();
 }
 
 // Make derived fields properly update their intended origin target

--- a/src/module/token.ts
+++ b/src/module/token.ts
@@ -39,7 +39,7 @@ export class LancerTokenDocument extends TokenDocument {
   }
 
   async _preCreate(...[data, options, user]: Parameters<TokenDocument["_preCreate"]>) {
-    if (getAutomationOptions().token_size) {
+    if (getAutomationOptions().token_size && !this.actor?.getFlag(game.system.id, "manual_token_size")) {
       const new_size = Math.max(1, this.actor?.system.size ?? 1);
       // @ts-expect-error v10
       this.updateSource({ width: new_size, height: new_size });
@@ -51,12 +51,9 @@ export class LancerTokenDocument extends TokenDocument {
     // @ts-expect-error
     super._onRelatedUpdate(update, options);
 
-    if (getAutomationOptions().token_size) {
-      const data = update instanceof Array ? update[0] : update;
-      console.log(data);
+    if ((getAutomationOptions().token_size && !game.system.id, "manual_token_size")) {
       let new_size = this.actor?.system.size;
       if (new_size !== undefined) this.update({ width: Math.max(1, new_size), height: Math.max(1, new_size) });
-      console.log(new_size);
     }
   }
 }

--- a/src/module/token.ts
+++ b/src/module/token.ts
@@ -1,3 +1,4 @@
+import { getAutomationOptions } from "./settings";
 import { correctLegacyBarAttribute } from "./util/migrations";
 
 declare global {
@@ -35,6 +36,28 @@ export class LancerTokenDocument extends TokenDocument {
 
     // @ts-expect-error
     return super.migrateData(source);
+  }
+
+  async _preCreate(...[data, options, user]: Parameters<TokenDocument["_preCreate"]>) {
+    if (getAutomationOptions().token_size) {
+      const new_size = Math.max(1, this.actor?.system.size ?? 1);
+      // @ts-expect-error v10
+      this.updateSource({ width: new_size, height: new_size });
+    }
+    return super._preCreate(data, options, user);
+  }
+
+  _onRelatedUpdate(update: any, options: any) {
+    // @ts-expect-error
+    super._onRelatedUpdate(update, options);
+
+    if (getAutomationOptions().token_size) {
+      const data = update instanceof Array ? update[0] : update;
+      console.log(data);
+      let new_size = this.actor?.system.size;
+      if (new_size !== undefined) this.update({ width: Math.max(1, new_size), height: Math.max(1, new_size) });
+      console.log(new_size);
+    }
   }
 }
 


### PR DESCRIPTION
Adds a setting for aggressively managing token sizes.
- [x] Base setting to automate size
- [x] Add ~~actor~~ token flag to opt out of sizing on a per-actor basis
- [x] Extend TokenConfig to allow changing the flag on  a token (or prototype token)
- [x] (?) Set prototype token size when adding a frame or npc_class or adjusting deployable size even when the automation is disabled?