### PR TITLE
Add integration for Carousel Combat Tracker

### DIFF
--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -661,7 +661,20 @@ Hooks.once("init", async function () {
   //   }
   // });
 
+  // Combat tracker HUD modules integration
   Hooks.on("renderCombatCarousel", handleRenderCombatCarousel);
+  if (game.modules.get("combat-tracker-dock")?.active) {
+    game.lancer.combatTrackerDock = await import("./module/integrations/combat-tracker-dock");
+    (game.lancer.combatTrackerDock as any).renderHook = Hooks.on(
+      "renderCombatDock",
+      (...[_app, html]: Parameters<Hooks.RenderApplication>) => {
+        html.find(".buttons-container [data-action='roll-all']").hide();
+        html.find(".buttons-container [data-action='roll-npc']").hide();
+        // html.find(".buttons-container [data-action='previous-turn']").hide();
+        html.find(".buttons-container [data-action='next-turn']").hide();
+      }
+    );
+  }
 
   // Extend TokenConfig for token size automation
   Hooks.on("renderTokenConfig", extendTokenConfig);

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -665,15 +665,12 @@ Hooks.once("init", async function () {
   Hooks.on("renderCombatCarousel", handleRenderCombatCarousel);
   if (game.modules.get("combat-tracker-dock")?.active) {
     game.lancer.combatTrackerDock = await import("./module/integrations/combat-tracker-dock");
-    (game.lancer.combatTrackerDock as any).renderHook = Hooks.on(
-      "renderCombatDock",
-      (...[_app, html]: Parameters<Hooks.RenderApplication>) => {
-        html.find(".buttons-container [data-action='roll-all']").hide();
-        html.find(".buttons-container [data-action='roll-npc']").hide();
-        // html.find(".buttons-container [data-action='previous-turn']").hide();
-        html.find(".buttons-container [data-action='next-turn']").hide();
-      }
-    );
+    Hooks.on("renderCombatDock", (...[_app, html]: Parameters<Hooks.RenderApplication>) => {
+      html.find(".buttons-container [data-action='roll-all']").hide();
+      html.find(".buttons-container [data-action='roll-npc']").hide();
+      // html.find(".buttons-container [data-action='previous-turn']").hide();
+      html.find(".buttons-container [data-action='next-turn']").hide();
+    });
   }
 
   // Extend TokenConfig for token size automation

--- a/src/module/combat/lancer-combat.ts
+++ b/src/module/combat/lancer-combat.ts
@@ -97,7 +97,6 @@ export class LancerCombat extends Combat {
   async activateCombatant(id: string, override = false): Promise<this | undefined> {
     if (!(game.user?.isGM || (this.turn == null && this.combatants.get(id)?.isOwner) || override))
       return this.requestActivation(id);
-    // if (!game.user?.isGM && !override) return this.requestActivation(id);
     const combatant = <LancerCombatant | undefined>this.getEmbeddedDocument("Combatant", id);
     if (!combatant?.activations.value) return this;
     await combatant?.modifyCurrentActivations(-1);

--- a/src/module/integrations/combat-tracker-dock.ts
+++ b/src/module/integrations/combat-tracker-dock.ts
@@ -1,0 +1,81 @@
+import type { LancerActor } from "../actor/lancer-actor";
+import type { LancerCombatant } from "../combat/lancer-combat";
+import { getTrackerAppearance } from "../combat/lancer-combat-tracker";
+
+/**
+ * Creates a short description to be displayed under the name of the combatant
+ * in the tooltip. Not particularly useful atm as is only displays to players
+ * with ownership/observer permissions.
+ */
+export function generateDescription(actor: LancerActor) {
+  if (actor.is_deployable()) {
+    const deployer = actor.system.owner?.value?.name ?? null;
+    if (deployer !== null) return `Deployer: ${deployer}`;
+  }
+  if (actor.is_npc()) {
+    return (
+      (actor.system.class?.system.role?.toUpperCase() ?? "UNKNOWN") +
+      ": " +
+      [actor.system.class?.name, ...actor.itemTypes.npc_template.map(t => t.name?.toUpperCase())].join(" // ")
+    );
+  }
+}
+
+/**
+ * Parameters for the initiative display. Use this to display the total
+ * activations instead of the initiative value.
+ */
+export function getInitiativeDisplay(combatant: LancerCombatant) {
+  // rollIcon should never show up, so if it does, something broke and display an error icon
+  return { value: combatant?.activations.max, icon: "cci cci-activate", rollIcon: "fas fa-triangle-exclamation" };
+}
+
+function getColorByDispo(d: number) {
+  const app = getTrackerAppearance();
+  if (d === 2) return app.player_color;
+  else if (d === 1) return app.friendly_color;
+  else if (d === 0) return app.neutral_color;
+  else if (d === -1) return app.enemy_color;
+  else return null;
+}
+
+interface SystemIcon {
+  icon: string;
+  fontSize: string;
+  color?: string | null | undefined;
+  enabled?: boolean;
+  visible?: boolean;
+  // I legitimately do not know what the type on event is as it's not documented.
+  callback?: (event: unknown, combatant: LancerCombatant, iconIndex: number, iconId: string) => unknown;
+  id?: string;
+}
+
+/**
+ * Get an array of icons to be displayed on the card when the option is
+ * enabled. Displays an activation button for each remaining activation and a
+ * deactivate button if the combatant is the current turn.
+ */
+export function getSystemIcons(combatant: LancerCombatant) {
+  const icons: SystemIcon[] = [];
+  for (let i = 0; i < (combatant.activations.value ?? 0); ++i) {
+    icons.push({
+      icon: "cci cci-activate",
+      color: getColorByDispo(combatant.disposition),
+      fontSize: "1.5rem",
+      visible: true,
+      enabled: true,
+      callback: (_e, combatant) => combatant.parent?.activateCombatant(combatant.id!),
+    });
+  }
+  // @ts-expect-error
+  if (combatant.parent?.current.combatantId === combatant.id) {
+    icons.push({
+      icon: "cci cci-deactivate",
+      fontSize: "1.5rem",
+      visible: true,
+      enabled: combatant?.isOwner,
+      callback: (_e, combatant) => combatant.parent?.deactivateCombatant(combatant.id!),
+    });
+  }
+  return icons;
+}


### PR DESCRIPTION
Fixes up some combat details and adds a hook and an api for integration with the Carousel Combat Tracker module (combat-tracker-dock). For the integration, on the system side, the initiative value is initialized to 0 for all combatants if null so that the dock removes the roll initiative button (so we don't have to).

On the module side, we provide a function that gets a short description for deployables and npcs and a function to supply a list of buttons, which we use to show remaining activations and a deactivate button for the current combatant.