### PR TITLE
2.0 - Don't allow NPC Traits to be marked as destroyed

### DIFF
--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -33,6 +33,7 @@ import {
   DamageType,
   EntryType,
   FittingSize,
+  NpcFeatureType,
   RangeType,
   ReserveType,
   SystemType,
@@ -1524,7 +1525,9 @@ function _handleContextMenus(
       return (
         !view_only &&
         item instanceof LancerItem &&
-        (item.is_mech_system() || item.is_mech_weapon() || item.is_npc_feature()) &&
+        (item.is_mech_system() ||
+          item.is_mech_weapon() ||
+          (item.is_npc_feature() && item.system.type !== NpcFeatureType.Trait)) &&
         !item.system.destroyed
       );
     },


### PR DESCRIPTION
Resolves https://github.com/Eranziel/foundryvtt-lancer/issues/394

As per discussion there, this may not be something you intend to 'fix':

> I think this is an important note to have for if/when we do implement system/weapon destruction automation (NPC or otherwise). Though I suspect the existence of the destroyed toggle is fine and should probably be won't fix, since it's not going to simplify the underlying code.

However, I believe the underlying bug is still valid, in that NPC traits *are* indestructible, and to assist new players & DMs the Foundry System should mimic the expected behaviour from the System rules.

Regardless, this was super easy to do - so if you choose not to merge it, no worries.

---

Import the `NpcFeatureType` Enum, explicitly ignore NPC features with `item.system.type` "Trait" when returning the Context Menu.