### PR TITLE
2.0 - Remove linked class/template features on item deletion

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -5,7 +5,14 @@ import { AppliedDamage } from "./damage-calc";
 import { SystemData, SystemDataType, SystemTemplates } from "../system-template";
 import { SourceDataType } from "../source-template";
 import { getAutomationOptions } from "../settings";
-import { LancerBOND, LancerFRAME, LancerItem, LancerNPC_CLASS } from "../item/lancer-item";
+import {
+  LancerBOND,
+  LancerFRAME,
+  LancerItem,
+  LancerNPC_CLASS,
+  LancerNPC_FEATURE,
+  LancerNPC_TEMPLATE,
+} from "../item/lancer-item";
 import { LancerActiveEffect } from "../effects/lancer-active-effect";
 import { frameToPath } from "./retrograde-map";
 import { EffectHelper } from "../effects/effector";
@@ -633,6 +640,16 @@ export class LancerActor extends Actor {
   // Quick checkers
   hasHeatcap(): this is { system: SystemTemplates.heat } {
     return (this as any).system.heat !== undefined;
+  }
+
+  async removeClassFeatures(item: LancerItem) {
+    if (!this.is_npc() || (!item.is_npc_class() && !item.is_npc_template())) return;
+    const targetFeatures = [...item.system.base_features, ...item.system.optional_features];
+    let matches = this.itemTypes.npc_feature.filter(feat => targetFeatures.includes(feat.system.lid));
+    await this._safeDeleteDescendant(
+      "Item",
+      matches.filter(x => x)
+    );
   }
 
   /**

--- a/src/module/actor/npc-sheet.ts
+++ b/src/module/actor/npc-sheet.ts
@@ -190,16 +190,13 @@ function getStatInput(event: Event): HTMLInputElement | HTMLDataElement | null {
 }
 
 // Removes class/features when a delete of class/template happens
-function handleClassDelete(ctx: GenControlContext) {
-  if (ctx.action == "delete") {
-    let pt = ctx.path_target as LancerItem;
-    if (pt instanceof LancerItem && (pt.is_npc_template() || pt.is_npc_class())) {
-      let matches = findMatchingFeaturesInNpc(ctx.target_document, [
-        ...pt.system.base_features,
-        ...pt.system.optional_features,
-      ]);
-      ctx.target_document.deleteEmbeddedDocuments("Item", matches.map(m => m.id).filter(x => x) as string[]);
-    }
+export function handleClassDelete(item: LancerItem, npc: LancerNPC) {
+  if (item.is_npc_template() || item.is_npc_class()) {
+    let matches = findMatchingFeaturesInNpc(npc, [
+      ...item.system.base_features,
+      ...item.system.optional_features,
+    ]);
+    npc.deleteEmbeddedDocuments("Item", matches.map(m => m.id).filter(x => x) as string[]);
   }
 }
 

--- a/src/module/actor/npc-sheet.ts
+++ b/src/module/actor/npc-sheet.ts
@@ -129,11 +129,9 @@ export class LancerNPCSheet extends LancerActorSheet<EntryType.NPC> {
       if (this.actor.is_npc() && doc.is_npc_class() && old_class) {
         // But before we do that, destroy all old classes
         // If we have a class, get rid of it
-        let class_features = findMatchingFeaturesInNpc(this.actor, [
-          ...old_class.system.base_features,
-          ...old_class.system.optional_features,
-        ]);
-        await this.actor._safeDeleteDescendant("Item", [old_class, ...class_features]);
+        await this.actor.removeClassFeatures(old_class);
+        // And then destroy it
+        await old_class.delete();
       }
 
       // And add all new features
@@ -187,29 +185,4 @@ function getStatInput(event: Event): HTMLInputElement | HTMLDataElement | null {
   return $(event.currentTarget).closest(".stat-container").find(".lancer-stat")[0] as
     | HTMLInputElement
     | HTMLDataElement;
-}
-
-// Removes class/features when a delete of class/template happens
-export function handleClassDelete(item: LancerItem, npc: LancerNPC) {
-  if (item.is_npc_template() || item.is_npc_class()) {
-    let matches = findMatchingFeaturesInNpc(npc, [
-      ...item.system.base_features,
-      ...item.system.optional_features,
-    ]);
-    npc.deleteEmbeddedDocuments("Item", matches.map(m => m.id).filter(x => x) as string[]);
-  }
-}
-
-// Given a list of npc features, return the corresponding entries on the provided npc
-export function findMatchingFeaturesInNpc(npc: LancerNPC, feature_ids: string[]): LancerNPC_FEATURE[] {
-  if (!npc.is_npc()) return [];
-  let result = [];
-  for (let predicate_lid of feature_ids) {
-    for (let candidate_feature of npc.itemTypes.npc_feature as LancerNPC_FEATURE[]) {
-      if (candidate_feature.system.lid == predicate_lid) {
-        result.push(candidate_feature);
-      }
-    }
-  }
-  return result;
 }

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -1535,6 +1535,10 @@ function _handleContextMenus(
     name: "Delete Document",
     icon: '<i class="fas fa-fw fa-trash"></i>',
     callback: async (html: JQuery) => {
+      let item = dd(html)?.terminus as LancerItem | null;
+      if (item instanceof LancerItem && doc instanceof LancerActor) {
+        handleClassDelete(item, doc as LancerNPC);
+      }
       (dd(html)?.terminus as foundry.abstract.Document<any, any> | null)?.delete();
     },
     condition: html => !view_only && dd(html)?.terminus instanceof foundry.abstract.Document,

--- a/src/module/helpers/item.ts
+++ b/src/module/helpers/item.ts
@@ -1537,7 +1537,7 @@ function _handleContextMenus(
     callback: async (html: JQuery) => {
       let item = dd(html)?.terminus as LancerItem | null;
       if (item instanceof LancerItem && doc instanceof LancerActor) {
-        handleClassDelete(item, doc as LancerNPC);
+        doc.removeClassFeatures(item);
       }
       (dd(html)?.terminus as foundry.abstract.Document<any, any> | null)?.delete();
     },


### PR DESCRIPTION
Resolves https://github.com/Eranziel/foundryvtt-lancer/issues/424

Rework unused function `handleClassDelete` to take an item (the template or class) and an npc instead of using Context.

Conditonally call this function when we click "Delete Document" in a context menu.