### PR TITLE
Remove duplicate default effects

### DIFF
--- a/src/module/effects/lancer-active-effect.ts
+++ b/src/module/effects/lancer-active-effect.ts
@@ -194,9 +194,6 @@ export class LancerActiveEffect extends ActiveEffect {
     if (statusIconConfig.tommyConditionsStatus) {
       configStatuses = configStatuses.concat(tommyConditionsStatus);
     }
-    if (statusIconConfig.defaultConditionsStatus) {
-      configStatuses = configStatuses.concat(defaultStatuses);
-    }
     if (statusIconConfig.cancerConditionsStatus) {
       configStatuses = configStatuses.concat(cancerConditionsStatus);
     }


### PR DESCRIPTION
In the lancer active effects module, this block of code 

https://github.com/Eranziel/foundryvtt-lancer/blob/2.0-rc/src/module/effects/lancer-active-effect.ts#L174-L187

is duplicated here

https://github.com/Eranziel/foundryvtt-lancer/blob/2.0-rc/src/module/effects/lancer-active-effect.ts#L197-L199

So you end up with double status effects.