### PR TITLE
Fix pilot import tour

### DIFF
--- a/public/tours/pilot-import.json
+++ b/public/tours/pilot-import.json
@@ -6,7 +6,7 @@
   "steps": [
     {
       "id": "compconLogin",
-      "selector": "#sidebar #settings #settings-game #compcon-login",
+      "selector": "#sidebar #settings #compcon-login",
       "title": "lancer.tour.pilot-import.compconLogin.title",
       "content": "lancer.tour.pilot-import.compconLogin.content",
       "sidebarTab": "settings"


### PR DESCRIPTION
One of the selectors to locate the comp con login button got changed or
removed causing an error when launching the pilot import tour. This
removes that selector allowing the tour to be launched.
