### PR TITLE
Enable overcharge sequence bonuses

### DIFF
--- a/src/module/actor/lancer-actor.ts
+++ b/src/module/actor/lancer-actor.ts
@@ -35,7 +35,7 @@ import { rollEvalSync } from "../util/misc";
 
 const lp = LANCER.log_prefix;
 
-const DEFAULT_OVERCHARGE_SEQUENCE = ["+1", "+1d3", "+1d6", "+1d6+4"];
+const DEFAULT_OVERCHARGE_SEQUENCE = "+1,+1d3,+1d6,+1d6+4" as const;
 
 interface LancerActorDataSource<T extends EntryType> {
   type: T;

--- a/src/module/actor/struss-util.ts
+++ b/src/module/actor/struss-util.ts
@@ -72,7 +72,7 @@ export class StrussHelper {
     if (this.actor.is_npc()) {
       return "1d6"; // Some veterans can
     } else if (this.actor.is_mech()) {
-      const oc_rolls = this.actor.system.overcharge_sequence;
+      const oc_rolls = this.actor.system.overcharge_sequence.split(",");
       return oc_rolls[this.actor.system.overcharge];
     } else {
       return null;

--- a/src/module/effects/converter.ts
+++ b/src/module/effects/converter.ts
@@ -575,7 +575,10 @@ export function convertBonus(origin: string, name: string, bonus: BonusData): nu
       target_type = EntryType.MECH;
       changes.push({ mode, value: 1 as any, priority, key: "system.stress_repair_cost" });
       break;
-    // case "overcharge":
+    case "overcharge":
+      target_type = EntryType.MECH;
+      changes.push({ mode, value, priority, key: "system.overcharge_sequence" });
+      break;
     // case "limited_bonus":
     case "pilot_hp":
       target_type = EntryType.PILOT;

--- a/src/module/flows/overcharge.ts
+++ b/src/module/flows/overcharge.ts
@@ -36,7 +36,10 @@ async function initOverchargeData(state: FlowState<LancerFlowState.OverchargeRol
 
   state.data.title = options?.title || state.data.title || `${state.actor.name!.toUpperCase()} is OVERCHARGING`;
   state.data.roll_str = state.actor.strussHelper.getOverchargeRoll()!;
-  state.data.level = Math.min(state.actor.system.overcharge + 1, state.actor.system.overcharge_sequence.length - 1);
+  state.data.level = Math.min(
+    state.actor.system.overcharge + 1,
+    state.actor.system.overcharge_sequence.split(",").length - 1
+  );
 
   return state;
 }

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -341,7 +341,7 @@ export function npc_stat_array_clicker_card(title: string, path: string, options
  * @param options Options object to pass to resolveHelperDotpath
  */
 export function overchargeButton(actor: LancerMECH, overcharge_path: string, options: HelperOptions): string {
-  const sequence = actor.system.overcharge_sequence;
+  const sequence = actor.system.overcharge_sequence.split(",");
 
   let index = resolveHelperDotpath(options, overcharge_path) as number;
   index = Math.max(0, Math.min(sequence.length - 1, index));

--- a/src/module/system-template.ts
+++ b/src/module/system-template.ts
@@ -365,7 +365,7 @@ export namespace SystemData {
     meltdown_timer: number | null;
     notes: string;
     pilot: SystemTemplates.ResolvedSyncUuidRef<LancerPILOT> | null; // UUID to a LancerPILOT
-    overcharge_sequence: string[]; // Derived so its overrideable
+    overcharge_sequence: string; // Derived so its overrideable
 
     structure_repair_cost: number;
     stress_repair_cost: number;


### PR DESCRIPTION
In order to enable bonuses to override the overcharge sequence, this
converts the system property to a comma separated string and splits it
on access. Tested with the Heatfall Coolant System core bonus.

Fixes: #655
