### PR TITLE
Fix bad fallback when automation options is {}

### DIFF
--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -213,7 +213,7 @@ export function getAutomationOptions(useDefault = false): AutomationOptions {
   };
   if (useDefault) return def;
   const settings = (game.settings.get(game.system.id, LANCER.setting_automation) as Record<string, boolean>) ?? {};
-  if (settings == null || (typeof settings == "object" && settings.enabled)) {
+  if (settings == null || (typeof settings == "object" && (settings.enabled ?? true))) {
     return {
       ...def,
       ...settings,


### PR DESCRIPTION
Null-coalesce the master automation switch to true to prevent migrated
worlds with {} as the value of the setting from having automation
disabled.
