### PR TITLE
Fix LancerID text enricher

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -81,5 +81,6 @@
       "url": "https://massifpress.com/_next/image?url=%2Fimages%2Flegal%2Fpowered_by_Lancer-02.svg&w=640&q=75",
       "caption": "Powered by Lancer"
     }
-  ]
+  ],
+  "flags": { "hotReload": { "extensions": ["json", "hbs"], "paths": ["lang", "templates"] } }
 }

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -169,7 +169,7 @@ import { PilotGearModel } from "./module/models/items/pilot_gear";
 import { PilotWeaponModel } from "./module/models/items/pilot_weapon";
 import { importCC } from "./module/actor/import";
 
-import "./module/helpers/text-enrichers";
+import { addEnrichers } from "./module/helpers/text-enrichers";
 import { fromLid, fromLidMany, fromLidSync } from "./module/helpers/from-lid";
 import { SkillModel } from "./module/models/items/skill";
 import { LicenseModel } from "./module/models/items/license";
@@ -202,6 +202,7 @@ window.addEventListener("unhandledrejection", function (event) {
 /* ------------------------------------ */
 /* Initialize system                    */
 /* ------------------------------------ */
+addEnrichers();
 Hooks.once("init", async function () {
   console.log(`Initializing LANCER RPG System ${LANCER.ASCII}`);
 

--- a/src/module/helpers/text-enrichers.ts
+++ b/src/module/helpers/text-enrichers.ts
@@ -1,43 +1,45 @@
 import { fromLidSync } from "./from-lid";
 
-//@ts-expect-error v10
-CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
-  {
-    pattern: /@LancerID\[(.+?)\](?:{(.+?)})?/g,
-    enricher: async (match: string[], _opts: unknown) => {
-      const lid = match[1];
-      const label: string | undefined = match[2];
-      // Ideally, in the future, we'll have a way to get an initial index with the correct fields
-      await Promise.all(game.packs.filter(p => ["Actor", "Item"].includes(p.documentName)).map(db => db.getIndex()));
-      let doc = fromLidSync(lid);
-      const data = {
-        cls: ["content-link"],
-        icon: undefined as string | undefined,
-        dataset: {} as Record<string, string>,
-        name: label,
-      };
-      if (doc) {
-        if (doc instanceof foundry.abstract.Document) {
-          // @ts-expect-error v10
-          return doc.toAnchor({ attrs: { draggable: true }, classes: data.cls, name: data.name });
+export function addEnrichers() {
+  //@ts-expect-error v10
+  CONFIG.TextEditor.enrichers = CONFIG.TextEditor.enrichers.concat([
+    {
+      pattern: /@LancerID\[(.+?)\](?:{(.+?)})?/gm,
+      enricher: async (match: string[], _opts: unknown) => {
+        const lid = match[1];
+        const label: string | undefined = match[2];
+        // Ideally, in the future, we'll have a way to get an initial index with the correct fields
+        await Promise.all(game.packs.filter(p => ["Actor", "Item"].includes(p.documentName)).map(db => db.getIndex()));
+        let doc = fromLidSync(lid);
+        const data = {
+          cls: ["content-link"],
+          icon: undefined as string | undefined,
+          dataset: {} as Record<string, string>,
+          name: label,
+        };
+        if (doc) {
+          if (doc instanceof foundry.abstract.Document) {
+            // @ts-expect-error v10
+            return doc.toAnchor({ attrs: { draggable: true }, classes: data.cls, name: data.name });
+          }
+          data.name ??= doc.name || lid;
+          const doc_type = game.packs.get(doc.pack)?.documentName ?? "Item";
+          data.dataset.type = doc_type;
+          data.dataset.id = doc._id;
+          data.dataset.pack = doc.pack;
+          data.dataset.uuid = `Compendium.${data.dataset.pack}.${doc._id}`;
+          data.icon = CONFIG[doc_type].sidebarIcon;
+        } else {
+          data.cls.push("broken");
+          data.icon = "fas fa-unlink";
         }
-        data.name ??= doc.name || lid;
-        const doc_type = game.packs.get(doc.pack)?.documentName ?? "Item";
-        data.dataset.type = doc_type;
-        data.dataset.id = doc._id;
-        data.dataset.pack = doc.pack;
-        data.dataset.uuid = `Compendium.${data.dataset.pack}.${doc._id}`;
-        data.icon = CONFIG[doc_type].sidebarIcon;
-      } else {
-        data.cls.push("broken");
-        data.icon = "fas fa-unlink";
-      }
-      const a = document.createElement("a");
-      a.classList.add(...data.cls);
-      a.draggable = true;
-      Object.entries(data.dataset).forEach(([k, v]) => (a.dataset[k] = v));
-      a.innerHTML = `<i class="${data.icon}"></i>${data.name}`;
-      return a;
+        const a = document.createElement("a");
+        a.classList.add(...data.cls);
+        a.draggable = true;
+        Object.entries(data.dataset).forEach(([k, v]) => (a.dataset[k] = v));
+        a.innerHTML = `<i class="${data.icon}"></i>${data.name}`;
+        return a;
+      },
     },
-  },
-]);
+  ]);
+}


### PR DESCRIPTION
The vite upgrade caused the LancerID text enricher to get tree shaken
out, so trick the compiler into keeping it included in the final output.
