### PR TITLE
Add more white icons

### DIFF
--- a/public/assets/icons/corepower.svg
+++ b/public/assets/icons/corepower.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="112.79237mm"
+   height="112.79237mm"
+   viewBox="0 0 112.79237 112.79237"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   inkscape:export-filename="..\..\..\..\Github\foundryvtt-lancer\public\assets\icons\white\corepower.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   sodipodi:docname="LeftEmptyCPBar.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="283.19626"
+     inkscape:cy="225.21351"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" /><defs
+     id="defs1" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-65.694443,-79.143959)"><path
+       style="display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke-width:1.97872"
+       d="m 91.627707,95.274227 c 0,0 3.81114,-0.28255 8.22479,-0.21253 5.029883,0.0794 8.093263,-0.0944 8.208263,-0.46548 0.10069,-0.32471 0.14459,-2.40202 0.0969,-4.61398 -0.0624,-2.88399 0.13692,-4.07968 0.70518,-4.22667 1.07299,-0.27767 26.57876,-0.11009 27.10027,0.17838 0.2275,0.12507 0.41152,2.2235 0.40929,4.66108 -0.002,2.43772 -0.15842,4.52764 0.0401,4.64439 0.19859,0.11672 4.05927,0.2073 8.19441,0.20207 4.13521,-0.007 7.95701,0.23517 7.95701,0.23517 l 0.0505,89.789973 -61.047593,-0.31229 c 0.0198,-29.96004 0.0405,-59.92007 0.0609,-89.880113 z m 50.191753,65.372783 c -0.007,-0.3275 -6.88364,-1.85374 -14.66379,-3.76059 -7.78024,-1.90676 -14.69752,-3.76963 -14.69752,-3.76963 0.93973,-5.03665 2.89983,-14.81657 2.89983,-14.81657 l -13.73964,-1.67784 c 0,0 -0.38654,38.0889 -0.18534,38.20743 0.28463,0.16722 40.16115,1.3154 40.17933,0.47549 0.21566,-9.97697 0.20695,-14.65829 0.20695,-14.65829 z m 0.98383,-44.45154 c 0.13796,-14.86632 0.0561,-11.22464 -0.18186,-11.34233 -0.58067,-0.28708 -40.27512,-0.50329 -40.432,-0.22019 -0.20207,0.36484 -0.35536,11.26767 -0.15573,11.36561 0.10138,0.0502 7.24903,1.37163 15.88471,2.93777 l 15.70124,2.84761 -1.14716,4.81096 c -0.63094,2.64603 -1.67309,7.01592 -2.3161,9.71069 l -1.16914,4.89966 3.82064,0.6469 c 2.10139,0.35595 5.09888,0.8843 6.66108,1.17458 1.56221,0.29021 2.89499,0.45326 2.96192,0.36261 0.0662,-0.0902 0.23482,-12.32805 0.37261,-27.19425 z"
+       id="path17"
+       inkscape:label="Core Logo"
+       sodipodi:nodetypes="cssssccsscccccscccssccscsscsscsccccsc" /></g></svg>

--- a/public/assets/icons/white/accuracy.svg
+++ b/public/assets/icons/white/accuracy.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="accuracy.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-296 -170v-342l296 -170l296 170v342zM478 619h68v-137h137v-68h-137v-137h-68v137h-137v68h137v137z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/activate.svg
+++ b/public/assets/icons/white/activate.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="activate.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 838l-390 -390l25 -24l365 -366l390 390zM512 741l293 -293l-293 -293l-293 293zM444 604q-45 -20 -74 -62t-29 -94q0 -70 50.5 -120.5t120.5 -50.5t120.5 50.5t50.5 120.5q0 52 -29 94t-74 62v-80q16 -14 25 -33.5t9 -42.5q0 -43 -29.5 -72.5t-72.5 -29.5 t-72.5 29.5t-29.5 72.5q0 23 9 42.5t25 33.5v80zM478 653v-205h68v205h-68z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/activation_full.svg
+++ b/public/assets/icons/white/activation_full.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="activation_full.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M225 721l-10 -10l-79 -78v-370l89 -88h574l88 88v370l-88 88h-574zM341 603l376 -155l-376 -155l69 155z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/activation_quick.svg
+++ b/public/assets/icons/white/activation_quick.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="activation_quick.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M225 721l-10 -10l-78 -78v-370l88 -88h574l88 88v370l-88 88h-574zM253 653h518l48 -48v-314l-48 -48h-518l-48 48v314zM341 603l69 -155l-69 -155l376 155z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/ammo.svg
+++ b/public/assets/icons/white/ammo.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="ammo.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M183 606q-9 -35 6.5 -104.5t53.5 -136.5l5 -76l51 -89l178 103l-52 88l-63 42q-39 67 -91.5 115.5t-87.5 57.5v0zM360 709q-9 -35 6.5 -105t54.5 -136l63 -42l52 -89l118 68l-51 89l-64 42q-38 66 -91 114.5t-88 58.5v0zM538 811q-10 -35 6 -105t54 -136l64 -42l51 -89 l118 69l-51 88l-64 42q-38 67 -90.5 115.5t-87.5 57.5v0zM333 141l34 -59l178 102l-34 60zM570 278l34 -59l118 68l-34 59zM747 380l34 -59l118 68l-34 59z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/aoe_blast.svg
+++ b/public/assets/icons/white/aoe_blast.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="aoe_blast.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M888 448q0 -76 -30.5 -146t-79.5 -120q-50 -49 -120 -79.5t-146 -30.5t-146 30.5t-119 79.5q-50 50 -80.5 120t-30.5 146t30.5 146t80.5 119q49 50 119 80.5t146 30.5t146 -30.5t120 -80.5q49 -49 79.5 -119t30.5 -146v0zM729 665q-43 43 -97 66.5t-120 23.5 q-65 0 -119.5 -23.5t-97.5 -66.5t-66.5 -97.5t-23.5 -119.5q0 -66 23.5 -120t66.5 -97t97.5 -66.5t119.5 -23.5q66 0 120 23.5t97 66.5t66.5 97t23.5 120q0 65 -23.5 119.5t-66.5 97.5zM477 505v137h68v-137h-68zM477 254v137h68v-137h-68zM318 482h137v-69h-137v69z M569 482h136v-69h-136v69z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/aoe_burst.svg
+++ b/public/assets/icons/white/aoe_burst.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="aoe_burst.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M888 448q0 -76 -30.5 -146t-79.5 -120q-50 -49 -120 -79.5t-146 -30.5t-146 30.5t-119 79.5q-50 50 -80.5 120t-30.5 146t30.5 146t80.5 119q49 50 119 80.5t146 30.5t146 -30.5t120 -80.5q49 -49 79.5 -119t30.5 -146v0zM729 665q-43 43 -97 66.5t-120 23.5 q-65 0 -119.5 -23.5t-97.5 -66.5t-66.5 -97.5t-23.5 -119.5q0 -66 23.5 -120t66.5 -97t97.5 -66.5t119.5 -23.5q66 0 120 23.5t97 66.5t66.5 97t23.5 120q0 65 -23.5 119.5t-66.5 97.5zM341 448l171 171l171 -171l-171 -171z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/aoe_cone.svg
+++ b/public/assets/icons/white/aoe_cone.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="aoe_cone.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M390 833q91 -25 173 -73q81 -48 147 -114t114 -147t73 -173l9 -32l-750 -201l201 749zM253 189l569 153q-25 79 -63 145q-39 65 -91 117t-118 91q-65 38 -145 63z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/aoe_line.svg
+++ b/public/assets/icons/white/aoe_line.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="aoe_line.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M674 755l-542 -542l49 -48l590 590h-97zM819 707l-590 -590l48 -49l542 542v97zM580 789v-68h205v-205h68v273h-273z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/balance.svg
+++ b/public/assets/icons/white/balance.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="balance.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M643 929l-118 -117l52 -14l-31 -116q-8 1 -16.5 2t-16.5 1q-1 -1 -2.5 -1h-2.5l44 -91l85 57l-20 10t-21 9l31 116l58 -15zM267 880l-1 -166l47 27l60 -104q-8 -6 -15 -12.5t-14 -13.5l101 -33l18 101q-12 -3 -23.5 -7t-21.5 -9l-60 104l51 29l-142 84v0zM777 699l27 -46 l-104 -61q-6 8 -12.5 15t-13.5 13l-32 -96l99 -18q-3 11 -6.5 21.5t-8.5 19.5l104 60l29 -51l84 143h-166v0zM196 622l-160 -42l117 -118l14 52l116 -31q-2 -10 -2.5 -20t0.5 -20l95 45l-60 87q-6 -10 -11 -20.5t-9 -21.5l-116 31l16 58v0zM747 459l-90 -45l57 -84 q4 8 8.5 16t7.5 17l116 -31l-14 -52l160 43l-117 117l-15 -58l-116 31q2 12 3 23.5t0 22.5v0zM287 399q2 -10 5 -19.5t7 -18.5l-104 -60l-27 46l-83 -144l165 1l-29 52l103 59q7 -9 15 -18t17 -18l35 99l-104 21v0zM588 327l-18 -103q8 3 17 5.5t17 6.5l60 -104l-46 -27 l144 -83l-1 165l-52 -29l-59 103q9 7 18 15t17 17zM481 312l-89 -60q8 -5 16.5 -9.5t17.5 -7.5l-31 -116l-52 14l43 -160l117 117l-58 15l31 116q13 -2 25 -3t25 0l-45 94v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/barrage.svg
+++ b/public/assets/icons/white/barrage.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="barrage.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M38 923v-68l526 -526q11 -11 21.5 -15t19.5 -4t18 4.5t15 11.5q14 14 16 34t-18 40l-523 523h-75v0zM852 524q-13 0 -26.5 -1.5t-27.5 -4.5l18 -35q9 2 17.5 2.5t16.5 0.5q24 0 42.5 -6.5t31.5 -19.5q20 -21 24.5 -55.5t-8.5 -78.5q0 -3 -1 -6l-2 -6l-45 105l-18 -135 l-67 93l-3 -118l-76 37q18 22 30 44.5t19 45.5q8 30 5 59t-23 49q-12 12 -28.5 18t-34.5 6q-11 0 -22.5 -1.5t-22.5 -5.5q-13 -3 -26 -8.5t-25 -13.5l27 -27q9 4 17.5 7.5t16.5 5.5q10 3 18 4.5t16 1.5q12 0 21.5 -3.5t16.5 -10.5q10 -10 12.5 -28t-4.5 -43 q-8 -25 -25 -52.5t-42 -53.5q-26 -26 -54 -43t-52 -24q-25 -7 -43.5 -4.5t-28.5 12.5t-12.5 28.5t4.5 42.5q3 9 6.5 17.5t7.5 17.5l-27 28q-8 -13 -13.5 -26t-9.5 -26q-9 -31 -5.5 -60t23.5 -48q20 -20 48.5 -23.5t59.5 5.5q22 6 44.5 18t44.5 29l39 -80l-126 -3l93 -67 l-135 -18l101 -42q0 -1 -0.5 -1h-0.5q-45 -13 -79.5 -8.5t-54.5 25.5q-18 18 -24 45t0 62l-34 19q-10 -45 -3 -85t34 -67q30 -31 75.5 -36t95.5 9q50 15 102 47t100 80q48 47 80 99.5t46 102.5q15 50 9.5 95t-35.5 75q-19 19 -44 28t-54 10v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/burning.svg
+++ b/public/assets/icons/white/burning.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="burning.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M62 913q-1 -75 5 -146q6 -70 27 -130.5t61 -108.5q41 -48 108 -77q83 -35 104 -76q22 -40 -0.5 -69t-81.5 -38q-59 -10 -138 17q57 -49 111 -100q55 -51 105.5 -95t97.5 -78q46 -33 88 -47q10 -4 21 -6.5t23 -2.5q17 0 32.5 5t29.5 14q47 -13 88 -17.5t76 -1.5 q30 1 57.5 10t50.5 26q37 25 58 65q20 40 23.5 92t-11.5 114q-14 63 -47 131q2 13 1.5 25.5t-3.5 25.5q-3 14 -9.5 27t-15.5 24q-21 32 -56 63q-36 31 -78.5 62t-90.5 62l-94 62q117 -149 111.5 -205.5t-90.5 16.5q2 12 -1 23.5t-11 23.5q-2 5 -5.5 9.5t-7.5 8.5 q-27 34 -74.5 77.5t-99.5 107.5q28 -140 -1 -179q-30 -39 -89.5 -10t-134.5 111q-76 82 -139 185v0zM536 612q21 0 35.5 -14.5t14.5 -35.5t-14.5 -36t-35.5 -15t-36 15t-15 36t15 35.5t36 14.5v0zM831 503q34 0 58 -24t24 -58t-24 -58t-58 -24q-8 0 -15.5 1t-13.5 4 q-2 29 -15.5 53.5t-35.5 40.5q6 28 28 46.5t52 18.5v0zM680 424q35 0 59.5 -25t24.5 -60t-24.5 -59.5t-59.5 -24.5t-60 24.5t-25 59.5t25 60t60 25v0zM818 293q62 0 105.5 -44t43.5 -106t-43.5 -105.5t-105.5 -43.5q-35 0 -65.5 14.5t-50.5 40.5q0 4 0.5 8.5t0.5 8.5 q0 24 -9.5 44.5t-25.5 35.5q1 20 6 38t14 34q35 2 62.5 22t40.5 50q7 2 13.5 2.5t13.5 0.5v0zM527 272q18 0 31.5 -13.5t13.5 -32.5t-13.5 -32t-31.5 -13q-19 0 -32.5 13t-13.5 32t13.5 32.5t32.5 13.5v0zM593 139q30 0 51.5 -21.5t21.5 -51.5t-21.5 -51.5t-51.5 -21.5 t-51.5 21.5t-21.5 51.5t21.5 51.5t51.5 21.5v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/campaign.svg
+++ b/public/assets/icons/white/campaign.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="campaign.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M783 758q-35 0 -84.5 -22t-106.5 -61l-2 -1q-17 6 -37 9.5t-41 3.5q-50 0 -93.5 -19t-75.5 -51v0q-32 -32 -51 -75.5t-19 -93.5q0 -19 3 -38t9 -37v2q-65 -90 -90 -160.5t3 -98.5v0q29 -29 103.5 -1.5t167.5 96.5l2 2q9 -2 19.5 -3t21.5 -1q50 0 93.5 19t75.5 51v0 q32 32 51 75.5t19 93.5q0 12 -1.5 24t-3.5 24v-2q62 87 84.5 154.5t-4.5 95.5v0v0v0q-8 7 -19 11t-25 3h1v0zM733 721q8 1 15.5 -1.5t11.5 -7.5v0q16 -15 4 -53.5t-45 -90.5v-1q-8 14 -17.5 26.5t-20.5 23.5v0q-15 15 -33 27.5t-38 21.5l-1 1q38 25 69.5 39t53.5 15h1v0z M291 357q10 -23 23 -42.5t29 -35.5v0q12 -12 25.5 -22t27.5 -18l2 -1q-61 -42 -106 -58t-63 1v0q-17 18 0.5 65t61.5 110v1v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/content_manager.svg
+++ b/public/assets/icons/white/content_manager.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="content_manager.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 755l-341 -136v-137l341 -136l341 136v137zM512 687l256 -102l-256 -103l-256 103zM171 414v-137l341 -136l341 136v137l-341 -137z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/core_bonus.svg
+++ b/public/assets/icons/white/core_bonus.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="core_bonus.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M375 448l137 137l137 -137l-137 -137zM478 823v-88l-102 -102l-45 44l-48 -48l44 -45l-102 -102h-88v-68h88l102 -103l-44 -44l48 -48l45 44l102 -102v-89h68v89l103 102l44 -44l48 48l-44 44l102 103h89v68h-89l-102 103l44 44l-48 48l-44 -44l-103 102v88h-68zM512 673 l225 -225l-225 -225l-225 225z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/corebonus.svg
+++ b/public/assets/icons/white/corebonus.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="corebonus.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M375 448l137 137l137 -137l-137 -137zM478 823v-88l-102 -102l-45 44l-48 -48l44 -45l-102 -102h-88v-68h88l102 -103l-44 -44l48 -48l45 44l102 -102v-89h68v89l103 102l44 -44l48 48l-44 44l102 103h89v68h-89l-102 103l44 44l-48 48l-44 -44l-103 102v88h-68zM512 673 l225 -225l-225 -225l-225 225z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/corepower.svg
+++ b/public/assets/icons/white/corepower.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="112.79237mm"
+   height="112.79237mm"
+   viewBox="0 0 112.79237 112.79237"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   inkscape:export-filename="EmptyCPBar.svg"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   sodipodi:docname="LeftEmptyCPBar.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="283.19626"
+     inkscape:cy="225.21351"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" /><defs
+     id="defs1" /><g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-65.694443,-79.143959)"><path
+       style="display:inline;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:1.97872"
+       d="m 91.627707,95.274227 c 0,0 3.81114,-0.28255 8.22479,-0.21253 5.029883,0.0794 8.093263,-0.0944 8.208263,-0.46548 0.10069,-0.32471 0.14459,-2.40202 0.0969,-4.61398 -0.0624,-2.88399 0.13692,-4.07968 0.70518,-4.22667 1.07299,-0.27767 26.57876,-0.11009 27.10027,0.17838 0.2275,0.12507 0.41152,2.2235 0.40929,4.66108 -0.002,2.43772 -0.15842,4.52764 0.0401,4.64439 0.19859,0.11672 4.05927,0.2073 8.19441,0.20207 4.13521,-0.007 7.95701,0.23517 7.95701,0.23517 l 0.0505,89.789973 -61.047593,-0.31229 c 0.0198,-29.96004 0.0405,-59.92007 0.0609,-89.880113 z m 50.191753,65.372783 c -0.007,-0.3275 -6.88364,-1.85374 -14.66379,-3.76059 -7.78024,-1.90676 -14.69752,-3.76963 -14.69752,-3.76963 0.93973,-5.03665 2.89983,-14.81657 2.89983,-14.81657 l -13.73964,-1.67784 c 0,0 -0.38654,38.0889 -0.18534,38.20743 0.28463,0.16722 40.16115,1.3154 40.17933,0.47549 0.21566,-9.97697 0.20695,-14.65829 0.20695,-14.65829 z m 0.98383,-44.45154 c 0.13796,-14.86632 0.0561,-11.22464 -0.18186,-11.34233 -0.58067,-0.28708 -40.27512,-0.50329 -40.432,-0.22019 -0.20207,0.36484 -0.35536,11.26767 -0.15573,11.36561 0.10138,0.0502 7.24903,1.37163 15.88471,2.93777 l 15.70124,2.84761 -1.14716,4.81096 c -0.63094,2.64603 -1.67309,7.01592 -2.3161,9.71069 l -1.16914,4.89966 3.82064,0.6469 c 2.10139,0.35595 5.09888,0.8843 6.66108,1.17458 1.56221,0.29021 2.89499,0.45326 2.96192,0.36261 0.0662,-0.0902 0.23482,-12.32805 0.37261,-27.19425 z"
+       id="path17"
+       inkscape:label="Core Logo"
+       sodipodi:nodetypes="cssssccsscccccscccssccscsscsscsccccsc" /></g></svg>

--- a/public/assets/icons/white/d20-framed.svg
+++ b/public/assets/icons/white/d20-framed.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="206.24452mm"
+   height="208.30185mm"
+   viewBox="0 0 206.24452 208.30185"
+   version="1.1"
+   id="svg7454"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   sodipodi:docname="d20-framed.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs7448" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.175"
+     inkscape:cx="-125.71429"
+     inkscape:cy="951.42857"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="true"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata7451">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-60.919402,-152.02765)">
+    <path
+       id="path6029"
+       d="m 138.75084,246.82766 -20.03337,29.5879 c -0.58458,0.949 0.0191,2.1827 1.1255,2.30417 l 39.52772,4.18888 z m -18.85471,19.05021 14.29002,-23.22201 -14.54626,-8.72698 c -0.50676,-0.30368 -1.15019,0.0607 -1.15019,0.651 v 30.9013 c 0,0.7649 1.00404,1.0496 1.40643,0.39669 z m 2.05741,20.53065 36.8971,16.63784 c 1.00593,0.46502 2.15422,-0.27141 2.15422,-1.37793 v -12.46416 l -38.63375,-4.23253 c -0.84461,-0.0949 -1.18244,1.06097 -0.41757,1.43678 z m 15.41556,-48.9266 15.17069,-27.12999 c 0.82373,-1.33997 -0.68138,-2.89445 -2.04603,-2.11436 l -28.62373,18.71616 c -0.4688,0.30747 -0.45362,0.99835 0.0247,1.28683 z m 26.67257,1.93217 H 184.7697 L 166.62863,207.4556 c -0.59407,-0.9642 -1.59051,-1.44629 -2.58696,-1.44629 -0.99647,0 -1.99291,0.48209 -2.58698,1.44629 l -18.14107,31.95849 z m 44.40175,-5.48521 -14.54625,8.72888 14.29002,23.22202 c 0.40048,0.6529 1.40642,0.36821 1.40642,-0.3986 v -30.9013 c 0,-0.59027 -0.64342,-0.95468 -1.15019,-0.651 z m -17.7292,3.55304 15.47439,-9.24324 c 0.48019,-0.28851 0.49348,-0.97938 0.0247,-1.28685 l -28.6237,-18.71426 c -1.36466,-0.78009 -2.86977,0.77439 -2.04605,2.11436 z m 14.99799,47.48982 -38.63375,4.23064 v 12.46414 c 0,1.10843 1.1483,1.84297 2.15422,1.37795 l 36.89709,-16.63785 c 0.76489,-0.37391 0.42705,-1.52979 -0.41756,-1.43488 z m -16.37972,-38.14408 -20.61796,36.08095 39.52772,-4.18888 c 1.10653,-0.12338 1.71008,-1.35517 1.1255,-2.30417 z m -25.29082,-1.33998 h -19.0616 l 19.0616,33.35731 19.06159,-33.35731 z"
+       inkscape:connector-curvature="0"
+       style="display:inline;stroke-width:0.1897998;fill:#ffffff" />
+    <path
+       sodipodi:type="star"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:18;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="path5867-8-0"
+       sodipodi:sides="4"
+       sodipodi:cx="-67.18116"
+       sodipodi:cy="151.35423"
+       sodipodi:r1="91.359955"
+       sodipodi:r2="64.601242"
+       sodipodi:arg1="1.5707963"
+       sodipodi:arg2="2.3561945"
+       inkscape:flatsided="true"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       transform="matrix(0.99072308,0,0,1.0006057,230.59959,104.73266)" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_burn.svg
+++ b/public/assets/icons/white/damage_burn.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_burn.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M546 858l-22 -23t-51 -55.5t-57 -67.5t-41 -59q-25 -51 -24.5 -73t-9.5 -64q-17 -74 -59.5 -105t-42.5 -134q0 -75 44 -117t98 -63q-17 17 -28.5 36.5t-11.5 41.5q0 27 22 63q21 35 46.5 66.5t47.5 53.5l21 22l33 -20q33 -19 72.5 -49.5t70.5 -66.5q32 -36 29 -69 q-2 -15 -8.5 -30t-15.5 -29q49 26 87.5 66t38.5 95q0 77 -16 135q-16 57 -35 95.5t-35 57.5l-16 20l9 -70t-43 -67q-26 1 -39.5 36.5t-29.5 65.5q-25 52 -46.5 69t-21.5 68q0 77 17 124l17 47v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_energy.svg
+++ b/public/assets/icons/white/damage_energy.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_energy.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M580 858l-341 -478h273l-68 -342l341 478h-273z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_explosive.svg
+++ b/public/assets/icons/white/damage_explosive.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_explosive.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 824l-55 -247l-150 76l76 -150l-247 -55l247 -55l-76 -150l150 76l55 -246l55 246l150 -76l-76 150l246 55l-246 55l76 150l-150 -76z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_heat.svg
+++ b/public/assets/icons/white/damage_heat.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_heat.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 858q-43 0 -72.5 -30t-29.5 -73v-410q-33 -24 -51 -60t-18 -76q0 -71 50 -121t121 -50t121 50t50 121q0 40 -18 76t-51 60v410q0 43 -29.5 73t-72.5 30zM478 550h68v-245q31 -10 49.5 -36.5t18.5 -59.5q0 -42 -30 -72t-72 -30t-72 30t-30 72q0 33 18.5 59.5 t49.5 36.5v245zM683 516h136v-68h-136v68v0zM683 687h136v-68h-136v68z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_kinetic.svg
+++ b/public/assets/icons/white/damage_kinetic.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_kinetic.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M751 448q0 -48 -19.5 -93t-50.5 -76t-76 -50.5t-93 -19.5t-93 19.5t-76 50.5t-50.5 76t-19.5 93t19.5 93t50.5 76t76 50.5t93 19.5t93 -19.5t76 -50.5t50.5 -76t19.5 -93zM633 569q-25 24 -54.5 37t-66.5 13t-66.5 -13t-54.5 -37q-24 -25 -37 -54.5t-13 -66.5t13 -66.5 t37 -54.5q25 -24 54.5 -37t66.5 -13t66.5 13t54.5 37q24 25 37 54.5t13 66.5t-13 66.5t-37 54.5v0zM171 107q102 64 198 140q95 76 181.5 162.5t162.5 181.5q76 96 140 198q-102 -64 -198 -140q-95 -76 -181.5 -162.5t-162.5 -181.5q-76 -96 -140 -198v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/damage_variable.svg
+++ b/public/assets/icons/white/damage_variable.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="damage_variable.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M375 214q0 -42 -29.5 -71.5t-70.5 -29.5v0q-41 0 -70.5 29.5t-29.5 71.5v0q0 42 29.5 71.5t70.5 29.5v0q41 0 70.5 -29.5t29.5 -71.5v0zM851 687q0 -42 -29.5 -71.5t-70.5 -29.5v0q-41 0 -70.5 29.5t-29.5 71.5v0q0 42 29.5 71.5t70.5 29.5v0q41 0 70.5 -29.5t29.5 -71.5 v0zM612 448q0 -42 -29.5 -71.5t-70.5 -29.5v0q-41 0 -70.5 29.5t-29.5 71.5v0q0 42 29.5 71.5t70.5 29.5v0q41 0 70.5 -29.5t29.5 -71.5v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/deactivate.svg
+++ b/public/assets/icons/white/deactivate.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="deactivate.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 838l-390 -390l24 -24l366 -366l390 390zM478 653h68v-205h-68v205zM444 604v-80q-16 -14 -25 -33.5t-9 -42.5q0 -43 29.5 -72.5t72.5 -29.5t72.5 29.5t29.5 72.5q0 23 -9 42.5t-25 33.5v80q45 -20 74 -62t29 -94q0 -70 -50.5 -120.5t-120.5 -50.5t-120.5 50.5 t-50.5 120.5q0 52 29 94t74 62v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/deployable.svg
+++ b/public/assets/icons/white/deployable.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="deployable.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M444 789v-239h-69l137 -170l137 170h-69v239h-136v0zM363 457l-192 -77v-137l341 -136l341 136v137l-192 77l-41 -52l148 -59l-256 -103l-256 103l148 59l-41 52v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/difficulty.svg
+++ b/public/assets/icons/white/difficulty.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="difficulty.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-296 -170v-342l296 -170l296 170v342zM512 710l227 -131v-262l-227 -132l-227 132v262zM683 414h-342v68h342v-68z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/downtime.svg
+++ b/public/assets/icons/white/downtime.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="downtime.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789q-42 0 -80 -16q-37 -16 -65 -43.5t-44 -65.5q-16 -37 -16 -79v0q0 -43 16 -80t44 -65t65 -44q38 -16 80 -16v0q42 0 80 16q37 16 65 44t44 65t16 80v0q0 7 -0.5 14t-1.5 14v-1q-9 -56 -52 -93t-100 -37v0q-63 0 -108 45t-45 109v0q0 57 37 99.5t91 51.5h1 q-6 1 -13 1.5t-14 0.5v0v0zM239 346v-166q-18 -9 -35 -18.5t-33 -20.5l34 -34q51 38 134 57t173 19t173 -19t134 -57l34 34q-16 11 -33 20.5t-35 18.5v97h-68v-69q-66 23 -135 31t-138 0v38h-69v-49q-8 -2 -16.5 -4t-17.5 -5v127h-102v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/drone.svg
+++ b/public/assets/icons/white/drone.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="drone.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.6230469"
+     inkscape:cx="255.69194"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M290 789q-49 0 -84 -35t-35 -84t35 -84.5t84 -35.5q15 0 29.5 4.5t26.5 10.5l57 -56l-28 -27h-68v-68h68l28 -27l-56 -56q-13 7 -27.5 11t-29.5 4q-49 0 -84 -35.5t-35 -84.5t35 -84t84 -35t84.5 35t35.5 84q0 15 -4 29.5t-11 26.5l56 57l27 -28h68l27 27l56 -56 q-7 -12 -11 -26.5t-4 -29.5q0 -49 35.5 -84t84.5 -35t84 35t35 84t-35 84.5t-84 35.5q-15 0 -29.5 -4t-26.5 -11l-56 56l27 27h68v68h-68l-28 27l57 56q12 -7 26.5 -11t29.5 -4q49 0 84 35.5t35 84.5t-35 84t-84 35t-84.5 -35t-35.5 -84q0 -15 4 -29.5t11 -27.5l-56 -56 l-27 28h-68l-27 -28l-56 57q7 12 11 26.5t4 29.5q0 49 -35.5 84t-84.5 35v0zM290 721q22 0 36.5 -15t14.5 -36q0 -22 -14.5 -36.5t-36.5 -14.5q-21 0 -36 14.5t-15 36.5q0 21 15 36t36 15zM734 721q21 0 36 -15t15 -36q0 -22 -15 -36.5t-36 -14.5q-22 0 -36.5 14.5 t-14.5 36.5q0 21 14.5 36t36.5 15zM290 277q22 0 36.5 -14.5t14.5 -36.5q0 -21 -14.5 -36t-36.5 -15q-21 0 -36 15t-15 36q0 22 15 36.5t36 14.5zM734 277q21 0 36 -14.5t15 -36.5q0 -21 -15 -36t-36 -15q-22 0 -36.5 15t-14.5 36q0 22 14.5 36.5t36.5 14.5z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/eclipse.svg
+++ b/public/assets/icons/white/eclipse.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="eclipse.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M318 926l30 -259l-92 50l75 -145q28 40 72.5 64.5t97.5 24.5q43 0 80 -16q38 -16 66 -44.5t44 -65.5q17 -38 17 -81q0 -46 -19 -86t-51 -68l136 -59l-53 120l276 32l-253 89l164 107h-188l210 334l-260 -215l-6 146l-140 -169l-39 169l-45 -137l-122 209v0zM50 676 l97 -108l144 -52l-104 117l-137 43v0zM294 451l-99 -55l88 -9l-153 -191l181 97l-166 -321l250 255l12 -143l54 167q-70 14 -117.5 70t-49.5 130v0zM606 276q-18 -10 -38.5 -17t-42.5 -10l151 -272l-70 299v0zM500 212v0l-23 -120l38 -121l26 127l-41 114v0zM763 185l69 -97 l105 -25l-65 91l-109 31v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/edef.svg
+++ b/public/assets/icons/white/edef.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="edef.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-273 -68q0 -96 1.5 -167.5t9.5 -126.5l63 63q-3 6 -4.5 12.5t-1.5 13.5v0q0 29 20 49t48 20v0q29 0 49 -20t20 -49v0v0v0q0 -28 -20 -48t-49 -20v0q-7 0 -13.5 1.5t-13.5 4.5l1 -1l-86 -86q12 -40 33 -74t54 -67v130l136 137v97q-19 7 -30.5 24t-11.5 39v0v0v0 q0 28 20 48t48 20v0q28 0 48 -20t20 -48v0v0v0q0 -22 -11.5 -39t-30.5 -24v0v-119l-137 -136v-152q23 -18 50.5 -37t60.5 -39q61 38 104 70q44 33 74 65.5t48 67.5q19 35 29 78h-108l-84 -84q2 -6 3.5 -12.5t1.5 -14.5v0q0 -28 -20 -48t-48 -20v0q-28 0 -48 20t-20 48v0v0v0 q0 29 20 49t48 20v0q7 0 14 -1.5t13 -4.5v0l84 85v28q-19 8 -31 25t-12 38v0q0 29 20 49t49 20v0q21 0 38 -12t25 -31v0h71q1 39 1.5 82.5t0.5 96.5zM712 491q-6 -13 -15.5 -23t-21.5 -15h-1v-14h101q2 13 3.5 25.5t2.5 26.5h-69z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/encounter.svg
+++ b/public/assets/icons/white/encounter.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="encounter.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M239 772l-17 -34h-85v-34l68 -17v-51l34 -17l17 -52h34l17 52l34 17v51l69 17v34h-86l-17 34h-68zM717 772l-17 -34h-86v-34l69 -17v-51l34 -17l17 -52h34l17 52l34 17v51l68 17v34h-85l-17 34h-68zM137 670v-103l34 -17v111zM410 670l-35 -9v-59h35v68zM614 670v-68h35 v59zM887 670l-34 -9v-111l34 17v103zM461 619l-26 -52h-128v-51l103 -25v-77l51 -26l25 -77h52l25 77l51 26v77l103 25v51h-128l-26 52h-102zM205 585v-154h34v102l-17 17v35h-17zM802 585v-35l-17 -17v-102h34v154h-17zM512 567l51 -51l-51 -51l-51 51zM307 465v-154 l51 -25v166zM717 465l-51 -13v-166l51 25v154zM410 337v-230h51v153l-26 26v51h-25zM589 337v-51l-26 -26v-153h51v230h-25z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/evasion.svg
+++ b/public/assets/icons/white/evasion.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="evasion.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-102 -102l239 -239l-239 -239l102 -102l341 341l-341 341v0zM341 619l-170 -171l170 -171l52 52l-120 119l120 119z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/frame.svg
+++ b/public/assets/icons/white/frame.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="frame.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 107h-103v307h51v-68l52 -35v-204zM444 789l-34 -68h-171v-68l136 -34v-103l69 -34l34 -102h68l34 102l69 34v103l136 34v68h-171l-34 68h-136zM512 721l68 -68l-68 -68l-68 68zM547 107h102v307h-52v-68l-50 -35v-204zM785 585l-68 -18v-221l68 34v205zM239 585 l68 -18v-221l-68 34v205z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/free_action.svg
+++ b/public/assets/icons/white/free_action.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="free_action.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M546 721v-136h-68v-69h136v69l182 -137l-182 -137v69h-136v-69h68v-136l364 273zM171 585v-69h68v69h-68zM307 585v-69h103v69h-103zM171 380v-69h68v69h-68zM307 380v-69h103v69h-103z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/generic_item.svg
+++ b/public/assets/icons/white/generic_item.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="generic_item.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 760l-17 -9l-254 -147v-312l271 -157l271 157v312zM512 682l202 -117l-202 -117l-202 117z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/grenade.svg
+++ b/public/assets/icons/white/grenade.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="grenade.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M307 755v-68h68v-68h205v34l137 -171v-205l34 -34h34v239l-136 182v91h-342zM375 550q-51 -51 -61 -107q-11 -56 2 -110.5t40 -103.5q28 -50 54 -88h136q26 38 53 88q28 49 41 103.5t2 110.5t-62 107h-205z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/large_beam.svg
+++ b/public/assets/icons/white/large_beam.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="large_beam.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M35 929v-146l417 -380l-222 47l290 -228q2 22 19 38t40 16q25 0 43 -18t18 -43t-18 -42.5t-43 -17.5q-16 0 -29.5 8t-21.5 21l-210 6l313 -144l-249 -46l86 -30h242q2 8 3.5 16.5t3.5 16.5q-20 6 -33 23.5t-13 39.5q0 27 19.5 46.5t46.5 19.5q10 0 18.5 -2.5t15.5 -7.5 q9 14 19 26.5t21 23.5q-8 6 -13 14.5t-7 18.5q-6 -5 -13.5 -8t-16.5 -3q-19 0 -32 13t-13 32t13 32.5t32 13.5q13 0 24 -7t17 -18q8 12 22 19t30 7q19 0 35 -10t23 -26q19 9 37.5 15.5t38.5 10.5v135l-15 131l-77 -210l-78 329l-57 -223l-186 321l21 -240l-397 410h-164v0z M571 446q13 0 23.5 -7.5t13.5 -19.5q8 7 18.5 11t21.5 4q26 0 43.5 -18t17.5 -43q0 -26 -17.5 -44t-43.5 -18q-25 0 -43 18t-18 43q-3 -2 -7 -3t-9 -1q-16 0 -27 11.5t-11 27.5t11 27.5t27 11.5v0zM796 396q16 0 27.5 -11.5t11.5 -27.5t-11.5 -27.5t-27.5 -11.5t-27.5 11.5 t-11.5 27.5t11.5 27.5t27.5 11.5v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/license.svg
+++ b/public/assets/icons/white/license.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="license.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M205 666q-14 0 -24 -10t-10 -24v-368q0 -14 10 -24t24 -10h614q14 0 24 10t10 24v368q0 14 -10 24t-24 10h-614zM375 603q25 0 42.5 -17.5t17.5 -42.5q0 -24 -17.5 -41.5t-42.5 -17.5q-24 0 -41.5 17.5t-17.5 41.5q0 25 17.5 42.5t41.5 17.5zM580 567h205v-51h-205v51z M299 475h19q11 -12 26 -18.5t31 -6.5q17 0 32 6.5t26 18.5h19v-19q6 -3 12.5 -6.5t13.5 -8.5q13 -51 23.5 -78.5t10.5 -49.5q-18 -7 -36 -12t-37 -8l-40 32q-18 -1 -49.5 2t-56.5 10l-10 -38q-11 3 -22 6.5t-22 7.5q0 22 10.5 49.5t23.5 78.5q7 5 13.5 8.5t12.5 6.5v19z M580 474h205v-52h-205v52zM580 380h137v-51h-137v51z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/manufacturer.svg
+++ b/public/assets/icons/white/manufacturer.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="manufacturer.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M546 817q-25 0 -43.5 -15.5t-23.5 -39.5v0l-138 -115l-16 4t-18 2v0q-42 0 -72 -30t-30 -73q0 -17 6 -33.5t17 -30.5l-2 2l117 -163q-1 -4 -1.5 -7t-0.5 -6v-0.5v-0.5v-91l-68 -45v-68h410v68l-69 45v91v0v1q0 48 -30 84.5t-75 47.5l-103 146l113 97q6 -3 13 -4.5 t14 -1.5v0q6 0 11.5 1t11.5 3h-1l73 -73l-27 -27h-34v-35l103 -102h68l-90 90l103 102l89 -90v69l-102 102h-34v-34l-27 -27l-77 76q1 3 1 6.5v6.5v0v0v0q0 28 -20 48t-48 20v0v0zM307 585v0q4 0 9 -1.5t9 -2.5q3 -2 5 -3.5t0 0.5l99 -139q-16 -7 -30 -17t-25 -23l-93 130 q-4 5 -6 10.5t-2 10.5q0 15 10 25t24 10v0zM478 380q29 0 48.5 -20t19.5 -48q0 -29 -19.5 -49t-48.5 -20t-48.5 20t-19.5 49q0 28 19.5 48t48.5 20z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/marker.svg
+++ b/public/assets/icons/white/marker.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="marker.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 896l-448 -384h256l192 160l192 -160h256zM512 544l-104 -78h-344v-36h344l104 -78l104 78h344v36h-344zM64 384l448 -384l448 384h-256l-192 -160l-192 160h-256z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/mech.svg
+++ b/public/assets/icons/white/mech.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="mech.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 107h-103v307h51v-68l52 -35v-204zM444 789l-34 -68h-171v-68l136 -34v-103l69 -34l34 -102h68l34 102l69 34v103l136 34v68h-171l-34 68h-136zM512 721l68 -68l-68 -68l-68 68zM547 107h102v307h-52v-68l-50 -35v-204zM785 585l-68 -18v-221l68 34v205zM239 585 l68 -18v-221l-68 34v205z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/mech_system.svg
+++ b/public/assets/icons/white/mech_system.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="mech_system.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M580 789l-61 -61l-51 51l-48 -48l51 -51l-71 -71l-52 51l-48 -48l51 -52l-71 -71l-51 51l-48 -48l51 -51l-61 -61v-34l239 -239h34l61 61l51 -51l48 48l-51 51l72 71l51 -51l48 48l-51 52l71 71l51 -51l48 48l-51 51l61 61v34l-239 239h-34zM580 619l103 -103l-239 -239 l-103 103z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/mech_weapon.svg
+++ b/public/assets/icons/white/mech_weapon.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="mech_weapon.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M853 755l-217 -72v-97l-397 -397v-48h48l397 397h97zM171 755l72 -217h97l80 -80l48 48l-80 80v97zM604 370l-48 -48l181 -181h48v48z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/melee.svg
+++ b/public/assets/icons/white/melee.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="melee.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M853 789l-170 -68l-308 -307l103 -103l307 308zM602 563l24 -25l-170 -170l-24 24zM215 199l205 205l48 -48l-205 -205zM365 472l171 -171l-48 -48l-171 171z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/mine.svg
+++ b/public/assets/icons/white/mine.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="mine.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 789v-139q-24 -4 -45.5 -13t-39.5 -23l1 1l-75 74l-48 -48l74 -74q-13 -18 -22 -39t-13 -45v-1h-139v-68h139q4 -24 13 -45.5t23 -39.5l-1 1l-74 -75l48 -48l74 74q18 -13 39 -22t45 -13h1v-139h68v139q24 4 45.5 13.5t39.5 22.5l-1 -1l75 -74l48 48l-74 74 q13 18 22 39.5t13 44.5v1h139v68h-139q-4 24 -13 45.5t-23 39.5l1 -1l74 75l-48 48l-74 -74q-18 13 -39.5 22t-44.5 13h-1v139h-68zM440 569l72 -73l72 73l49 -49l-73 -72l73 -72l-49 -49l-72 73l-72 -73l-49 49l73 72l-73 72z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/nested_hexagons.svg
+++ b/public/assets/icons/white/nested_hexagons.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="nested_hexagons.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 917l-406 -235v-468l406 -235l406 235v468l-406 235v0zM512 875l370 -213v-428l-370 -213l-370 213v428l370 213v0zM512 814l-317 -183v-366l317 -183l317 183v366l-317 183v0zM512 772l281 -162v-324l-281 -162l-281 162v324l281 162v0zM512 710l-227 -131v-262 l227 -131l227 131v262l-227 131v0zM512 669l191 -111v-220l-191 -111l-191 111v220l191 111v0zM512 607l-137 -80v-158l137 -80l137 80v158l-137 80v0zM512 565l101 -58v-118l-101 -58l-101 58v118l101 58v0zM512 503l-48 -27v-56l48 -27l48 27v56l-48 27v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/npc_class.svg
+++ b/public/assets/icons/white/npc_class.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="npc_class.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 755q-56 0 -96.5 -40t-40.5 -96q0 -24 8 -45t21 -38l-77 -99q-12 5 -26 8t-28 3q-56 0 -96.5 -40t-40.5 -96q0 -57 40.5 -97t96.5 -40t96.5 40t40.5 97q0 23 -8 44t-21 38l77 99q12 -5 26 -8t28 -3t28 3t26 9l77 -100q-13 -17 -21 -38t-8 -44q0 -57 40.5 -97 t96.5 -40t96 40t40 97q0 56 -40 96t-96 40q-14 0 -28 -3t-26 -8l-77 99q13 17 20.5 38t7.5 45q0 56 -40 96t-96 40v0zM512 687q29 0 48.5 -20t19.5 -48q0 -29 -19.5 -49t-48.5 -20t-48.5 20t-19.5 49q0 28 19.5 48t48.5 20zM273 380q29 0 48.5 -20t19.5 -48q0 -29 -19.5 -49 t-48.5 -20t-48.5 20t-19.5 49q0 28 19.5 48t48.5 20zM751 380q29 0 48.5 -20t19.5 -48q0 -29 -19.5 -49t-48.5 -20t-48.5 20t-19.5 49q0 28 19.5 48t48.5 20z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/npc_feature.svg
+++ b/public/assets/icons/white/npc_feature.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="npc_feature.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M171 687v-307l68 -69v-102h546v102l68 69v307h-682zM478 619h68v-103h103v-68h-103v-102h-68v102h-103v68h103v103z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/npc_template.svg
+++ b/public/assets/icons/white/npc_template.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="npc_template.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 858l-84 -72l-109 -8l-9 -110l-71 -83l71 -84l9 -110l109 -8l84 -72l84 72l109 8l9 110l71 84l-71 83l-9 110l-109 8zM512 755q70 0 120.5 -50t50.5 -121q0 -70 -50.5 -120t-120.5 -50t-120.5 50t-50.5 120q0 71 50.5 121t120.5 50zM512 687q-43 0 -72.5 -30 t-29.5 -73q0 -42 29.5 -72t72.5 -30t72.5 30t29.5 72q0 43 -29.5 73t-72.5 30v0zM375 335v-297l137 103l137 -103v297l-33 -2l-104 -89l-104 89z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/npc_tier_custom.svg
+++ b/public/assets/icons/white/npc_tier_custom.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="npc_tier_custom.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M546 823q-102 0 -153.5 -34l-51.5 -34v-512l205 -205l205 205v512l-51 34t-154 34v0zM546 653l50 -102l112 -16l-81 -79l19 -112l-100 53l-100 -53l19 112l-81 79l112 16z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/orbit.svg
+++ b/public/assets/icons/white/orbit.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="orbit.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M499 908q-46 -1 -89 -11q-44 -10 -83.5 -27.5t-74.5 -41.5q-35 -25 -65 -55v0q-32 -31 -56 -68q-25 -37 -42.5 -78t-27.5 -86q-9 -45 -9 -93q0 -95 36 -179t98.5 -146.5t146.5 -98.5t179 -36q55 0 106 12t97 35l-3 -2q8 -9 19.5 -14.5t25.5 -5.5q25 0 42.5 18t17.5 43 q0 6 -1.5 12.5t-4.5 12.5v0q7 5 13.5 11t12.5 13q31 31 56 67q25 37 42.5 78t27.5 86q9 45 9 93v0.5v0.5v0v0v0q0 95 -36 179t-98.5 146.5t-146.5 98.5t-179 36h-7.5h-6.5h1v0zM515 878q88 -1 166 -35q77 -34 135 -92t91 -136q34 -78 34 -167q0 -44 -9 -86t-25 -80.5 t-39 -72.5q-24 -35 -53 -64v0q-5 -6 -11 -11t-12 -11h-1q-7 5 -15.5 7.5t-18.5 2.5q-25 0 -42.5 -17.5t-17.5 -42.5v-6t1 -6v1q-41 -21 -88.5 -32t-98.5 -11q-89 0 -167 34q-78 33 -136.5 91.5t-92.5 136.5q-34 79 -34 167q0 89 34 168q34 78 92.5 136.5t136.5 91.5 q78 34 167 34h2h2v0v0zM499 753q-62 -3 -115 -28t-93 -67v0v-13h50l15 -33l41 9l51 4l54 -26l27 -27l-17 -24l-54 -10l28 -39l9 -14l-25 -37l-38 11l-32 -14l-12 -24h-51l-21 26v47l-38 5l-20 -40l-6 -52l17 -42l32 -37l15 -46l-13 -15l-46 14q41 -63 108 -100.5t147 -37.5 q63 0 119 24q55 24 96.5 65.5t65.5 97.5q24 55 24 119q0 23 -3.5 45t-9.5 42l1 -2l-24 -67l-111 -102l-22 30l49 89l-2 55l-47 -31l-14 54l61 128h3q-38 29 -85.5 46t-100.5 17h-7.5h-6.5h1v0zM563 411l37 -9l12 -59l-59 -55l-10 -100l-38 -23l-27 60l-58 34l-27 74l25 56 l145 22v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/orbital.svg
+++ b/public/assets/icons/white/orbital.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="orbital.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 919q-49 0 -95.5 -10t-88.5 -28q-13 16 -31.5 25.5t-39.5 9.5q-37 0 -63.5 -26.5t-26.5 -63.5q0 -12 3.5 -24t9.5 -22q-32 -32 -58 -69q-25 -38 -43 -80.5t-28 -88.5q-9 -46 -9 -94q0 -97 37 -183q37 -85 101 -149t150 -101q85 -37 182 -37q98 0 183 37 q86 37 149.5 101t100.5 149q37 86 37 183t-37 183q-37 85 -100.5 149t-149.5 102q-85 37 -182 37h-1zM513 880q89 0 168 -34t137.5 -92.5t92.5 -137.5t34 -168q0 -90 -34 -169q-34 -78 -92.5 -137t-137.5 -92q-79 -34 -168 -34q-90 0 -169 34q-79 33 -138 92t-93 137 q-34 79 -34 169q0 44 9 87q8 42 24.5 80.5t40.5 73.5q23 35 52 64q11 -8 24 -12t28 -4q37 0 63 26t26 63q0 5 -0.5 10t-1.5 10q39 17 81.5 25.5t86.5 8.5h1zM512 776q-68 0 -129 -26q-60 -26 -105 -71t-71 -105q-26 -61 -26 -129q0 -69 26 -129t71 -105t105 -71 q61 -26 129 -26q53 0 101 15.5t88 43.5q11 -6 23.5 -9.5t25.5 -3.5q40 0 68 28t28 67q0 20 -7.5 36.5t-19.5 29.5q12 29 18 60t6 64q0 68 -26 129q-26 60 -71 105t-105 71t-129 26v0zM512 738q61 0 115 -23q53 -23 93 -62.5t63 -93.5q23 -53 23 -114q0 -27 -4.5 -52.5 t-13.5 -49.5q-9 4 -18.5 6t-19.5 2q-40 0 -68 -28t-28 -68q0 -15 5 -29.5t14 -26.5q-35 -23 -75.5 -35.5t-85.5 -12.5q-61 0 -114 23q-54 23 -94 63t-63 93q-23 54 -23 115t23 114q23 54 63 93.5t94 62.5q53 23 114 23v0zM510 699q-11 -48 -32.5 -91.5t-53.5 -75.5 q-31 -31 -72 -50t-89 -30q48 -12 91.5 -33t74.5 -53q32 -32 51 -73t30 -89q11 48 30 89t51 73t75 53t91 33q-48 11 -88.5 30t-72.5 50q-32 32 -53.5 75.5t-32.5 91.5v0zM510 526q31 0 53 -22t22 -52q0 -31 -22 -53t-53 -22q-30 0 -52 22t-22 53q0 30 22 52t52 22v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/overcharge.svg
+++ b/public/assets/icons/white/overcharge.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="overcharge.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M611 653l194 29l-71 -183l144 -134l-188 -59l-15 -196l-163 110l-163 -110l-15 196l-188 59l144 134l-71 183l194 -29l99 170zM449 579l-124 18l46 -117l-92 -85l120 -38l9 -125l104 71l104 -71l10 125l119 38l-91 85l45 117l-124 -18l-63 108zM580 448q0 -28 -20 -48 t-48 -20v0q-28 0 -48 20t-20 48v0q0 28 20 48t48 20v0q28 0 48 -20t20 -48v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/pilot.svg
+++ b/public/assets/icons/white/pilot.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="pilot.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M359 499v-37q-12 -6 -24.5 -13.5t-27.5 -17.5q-25 -102 -46.5 -156.5t-21.5 -99.5q21 -9 43 -15.5t45 -12.5l20 76q50 -13 113 -20t98 -5l81 -63q37 6 74 16t72 24q0 44 -21.5 99t-46.5 157q-15 10 -27.5 17.5t-23.5 13.5v37h-40q-22 -24 -51.5 -37.5t-62.5 -13.5 t-62.5 13.5t-51.5 37.5h-5h-34zM614 396l69 -68l-69 -68l-68 68zM631 636q0 -50 -34.5 -85t-84.5 -35v0q-49 0 -84 35t-35 85v0q0 49 35 84t84 35v0q50 0 84.5 -35t34.5 -84v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/protocol.svg
+++ b/public/assets/icons/white/protocol.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="protocol.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 755q-61 0 -117 -25t-98 -67t-67 -98t-25 -117h68q0 46 20 89t53.5 76.5t76.5 53.5t89 20q48 0 92.5 -22t77.5 -58l-68 -22l171 -69v196l-45 -63q-43 48 -102.5 77t-125.5 29v0zM512 516v0v0q-28 0 -48 -20t-20 -48v0v0v0v0v0q0 -28 20 -48t48 -20v0v0v0v0v0 q28 0 48 20t20 48v0v0v0v0v0q0 28 -20 48t-48 20v0v0v0v0zM751 448v0q0 -46 -20 -89t-53.5 -76.5t-76.5 -53.5t-89 -20q-48 0 -92.5 22t-77.5 58l68 22l-171 69v-196l45 63q43 -48 102.5 -77t125.5 -29q61 0 117 25t98 67t67 98t25 117v0h-68z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/range.svg
+++ b/public/assets/icons/white/range.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="range.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M249 48l-137 137l49 48l136 -136zM181 165l614 614l48 -48l-614 -614zM483 525l106 -106l-48 -48l-106 106zM863 661l-136 137l48 48l136 -137z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/rank_1.svg
+++ b/public/assets/icons/white/rank_1.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="rank_1.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M510 18l-327 168v692h658v-692zM215 205l295 -151l299 152v640h-594v-641zM509 272l-190 97v-100l189 -97l197 100v99z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/rank_2.svg
+++ b/public/assets/icons/white/rank_2.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="rank_2.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M510 18l-327 168v692h658v-692zM215 205l295 -151l299 152v640h-594v-641v0zM508 337l197 100v100l-196 -100l-190 97v-100zM509 272l-190 97v-100l189 -97l197 100v99z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/rank_3.svg
+++ b/public/assets/icons/white/rank_3.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="rank_3.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M510 18l-327 168v692h658v-692zM215 205l295 -151l299 152v640h-594v-641v0zM591 542l-29 92l77 58h-96l-31 92l-31 -91l-96 -1l77 -58l-29 -92l79 56zM508 337l197 100v100l-196 -100l-190 97v-100zM509 272l-190 97v-100l189 -97l197 100v99z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/reaction.svg
+++ b/public/assets/icons/white/reaction.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="reaction.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 721v-156q-32 -3 -63.5 -12.5t-62.5 -25.5l-51 77l-56 -38l48 -73q-23 -16 -46 -34t-45 -40l-50 25l-31 -61l91 -45l17 18q34 33 67 58.5t65 43.5q-9 -18 -14.5 -37.5t-5.5 -40.5q0 -71 50.5 -121t120.5 -50t120.5 50t50.5 121q0 21 -5.5 40.5t-14.5 37.5 q32 -18 65 -43.5t67 -58.5l17 -18l91 45l-31 61l-50 -25q-22 22 -45 40t-46 34l48 73l-56 38l-51 -77q-31 16 -62.5 25.5t-63.5 12.5v156h-68zM512 448q29 0 48.5 -20t19.5 -48q0 -29 -19.5 -48.5t-48.5 -19.5t-48.5 19.5t-19.5 48.5q0 28 19.5 48t48.5 20v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/reactor.svg
+++ b/public/assets/icons/white/reactor.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="reactor.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M853 448q0 -69 -27.5 -132.5t-72.5 -108.5t-108.5 -72.5t-132.5 -27.5t-132.5 27.5t-108.5 72.5t-72.5 108.5t-27.5 132.5t27.5 132.5t72.5 108.5t108.5 72.5t132.5 27.5t132.5 -27.5t108.5 -72.5t72.5 -108.5t27.5 -132.5v0zM705 641q-38 39 -86.5 59.5t-106.5 20.5 t-106.5 -20.5t-86.5 -59.5q-39 -38 -59.5 -86.5t-20.5 -106.5t20.5 -106.5t59.5 -86.5q38 -39 86.5 -59.5t106.5 -20.5t106.5 20.5t86.5 59.5q39 38 59.5 86.5t20.5 106.5t-20.5 106.5t-59.5 86.5zM614 448q0 -27 -13.5 -51t-37.5 -38l51 -88q48 27 75.5 74.5t27.5 102.5 h-103zM307 448q0 -55 27.5 -102.5t75.5 -74.5l51 88q-24 14 -37.5 38t-13.5 51h-103zM507 653q-25 -1 -50 -8t-47 -20l51 -88q12 6 24.5 9.5t26.5 3.5q13 0 26.5 -3.5t24.5 -9.5l51 88q-24 14 -51.5 21t-55.5 7v0zM546 448q0 -14 -10 -24t-24 -10v0q-14 0 -24 10t-10 24v0 q0 14 10 24t24 10v0q14 0 24 -10t10 -24v0zM578 448q0 -12 -5.5 -25.5t-13.5 -21.5t-21.5 -13.5t-25.5 -5.5t-25.5 5.5t-21.5 13.5t-13.5 21.5t-5.5 25.5t5.5 25.5t13.5 21.5t21.5 13.5t25.5 5.5t25.5 -5.5t21.5 -13.5t13.5 -21.5t5.5 -25.5v0zM514 449v0h-1v1v0h-0.5h-0.5 h-0.5h-0.5v0v-1h-1v0v-0.5v-0.5v-0.5v-0.5v0h1v-1v0h0.5h0.5h0.5h0.5v0v1h1v0v0.5v0.5v0.5v0.5v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/repair.svg
+++ b/public/assets/icons/white/repair.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="repair.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M218 254l136 136q26 26 34.5 85.5t33.5 85.5q26 26 55.5 33.5t81.5 0.5l-89 -87l15 -89l88 -15l88 89q7 -46 -0.5 -78.5t-33.5 -58.5q-25 -25 -85 -33.5t-85 -34.5l-82 -79h-68zM842 638v-380l-330 -191l-330 191v380l330 191zM251 599v-302l261 -151l262 151v302 l-262 151z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/reserve_mech.svg
+++ b/public/assets/icons/white/reserve_mech.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="reserve_mech.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M273 789l-102 -102v-68h34l136 136v34h-68v0zM683 789v-34l136 -136h34v68l-102 102h-68v0zM478 687v-72q-16 -3 -31.5 -9.5t-28.5 -15.5l-51 51l-48 -48l51 -51q-9 -13 -15.5 -28.5t-9.5 -31.5h-72v-68h72q3 -16 9.5 -31.5t15.5 -28.5l-51 -51l48 -48l51 51 q13 -9 28.5 -15.5t31.5 -9.5v-72h68v72v0q16 3 31.5 9.5t28.5 15.5l51 -51l48 48l-51 51q9 13 15.5 28.5t9.5 31.5h72v68h-72q-3 16 -9.5 31.5t-15.5 28.5l51 51l-48 48l-51 -51q-14 9 -29 15.5t-31 9.5v72h-68v0zM512 550q43 0 72.5 -29.5t29.5 -72.5t-29.5 -72.5 t-72.5 -29.5t-72.5 29.5t-29.5 72.5t29.5 72.5t72.5 29.5zM171 277v-68l102 -102h68v34l-136 136h-34v0zM819 277l-136 -136v-34h68l102 102v68h-34v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/reserve_tac.svg
+++ b/public/assets/icons/white/reserve_tac.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="reserve_tac.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="1912"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M273 789l-102 -102v-68h34l136 136v34h-68v0zM683 789v-34l136 -136h34v68l-102 102h-68v0zM512 687q-49 0 -84 -35t-35 -85q0 -49 35 -84t84 -35t84 35t35 84q0 50 -35 85t-84 35zM358 431v-37q-11 -7 -23.5 -14.5l-27.5 -16.5q-3 -12 -5.5 -21.5t-5.5 -19.5l216 -113 l216 113q-3 10 -5.5 19.5t-5.5 21.5l-27.5 16.5t-23.5 14.5v37h-40q-16 -18 -36.5 -30t-43.5 -17v-73l-34 -34l-34 34v73q-23 5 -43.5 17t-36.5 30h-40v0zM171 277v-68l102 -102h68v34l-136 136h-34v0zM819 277l-136 -136v-34h68l102 102v68h-34v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/reticule.svg
+++ b/public/assets/icons/white/reticule.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="reticule.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M530 921v-116q69 -3 129 -31q60 -27 105 -72.5t73 -105.5q27 -60 31 -128h115q-3 92 -40 173q-36 81 -97 142t-142 98q-81 36 -174 40v0zM493 921q-92 -4 -173 -41q-81 -36 -142 -97t-98 -142q-36 -81 -40 -173h117q3 68 31 128q27 60 72 105t105 73q60 27 128 31v116v0z M512 706q-48 0 -91 -16.5t-77 -45.5l45 -45q18 15 40 25.5t47 15.5l37 -141l38 140q24 -4 45.5 -14.5t39.5 -25.5l44 45q-33 29 -76 45.5t-92 16.5v0zM707 617l-45 -44q15 -18 25.5 -40t14.5 -46l-140 -37l140 -38q-4 -24 -14.5 -46t-25.5 -40l44 -45q30 34 46.5 77t16.5 92 q0 48 -16.5 91t-45.5 76v0zM317 617q-29 -34 -45.5 -76.5t-16.5 -90.5q0 -49 16.5 -92t46.5 -77l45 45q-15 19 -25.5 40.5t-15.5 45.5l142 38l-141 38q4 23 14.5 44.5t24.5 39.5l-45 45v0zM40 430q4 -92 41 -173q36 -80 97 -141t142 -98t173 -41v117q-68 4 -127 31 q-60 28 -105 73t-73 105q-27 59 -31 127h-117v0zM868 430q-4 -68 -31 -128q-28 -59 -73.5 -104.5t-105.5 -72.5q-59 -28 -128 -31v-117q93 4 174 41q80 36 141 97t98 142t40 173h-115v0zM513 401l-38 -143q-24 5 -46 15.5t-40 26.5l-45 -45q34 -30 77 -46.5t91 -16.5 q49 0 91.5 16.5t76.5 45.5l-45 45q-18 -15 -39 -25.5t-45 -14.5l-38 142v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_artillery.svg
+++ b/public/assets/icons/white/role_artillery.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_artillery.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 789l-68 -136l-69 -546h342l-69 546l-68 136v-546h-68v546zM273 107l34 273l-68 -69l-103 -204h137zM751 107l-34 273l68 -69l102 -204h-136z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_controller.svg
+++ b/public/assets/icons/white/role_controller.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_controller.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M291 625q-68 -33 -111 -98.5t-43 -146.5q0 -57 21 -106q22 -50 59 -87t87 -59q49 -21 106 -21q56 0 106 21q50 22 87 59t58 87q22 49 22 106q0 80 -42.5 145t-109.5 99q-14 -11 -25 -25t-17 -30q55 -23 90 -74t35 -115q0 -43 -16 -80q-16 -38 -43.5 -65.5t-64.5 -43.5 q-38 -16 -80 -16q-43 0 -80 16q-38 16 -65.5 43.5t-43.5 65.5q-16 37 -16 80q0 46 18.5 85.5t50.5 67.5q1 24 5.5 47t11.5 45v0zM614 789q-56 0 -106 -21q-50 -22 -87 -59t-58 -87q-22 -49 -22 -106q0 -80 42.5 -145.5t109.5 -98.5q14 11 24.5 25t17.5 30q-55 23 -90 74 t-35 115q0 43 16 80t43.5 65t64.5 44q38 16 80 16q43 0 80 -16t65 -44t44 -65t16 -80q0 -46 -18.5 -85.5t-50.5 -67.5q-1 -24 -5.5 -47t-11.5 -45q68 33 111 98.5t43 146.5q0 57 -21 106q-22 50 -59 87t-87 59q-49 21 -106 21v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_defender.svg
+++ b/public/assets/icons/white/role_defender.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_defender.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 824l-29 -16t-73.5 -35.5t-99.5 -35.5q-54 -16 -105 -16l2 -30t6 -73t10 -90q7 -47 16 -80q17 -63 40 -125t62 -114q33 -43 76.5 -77t94.5 -59q51 25 94.5 59t76.5 77q39 52 62 114t40 125q9 33 15 80q7 47 11 90t6 73l2 30q-51 0 -105 16q-55 16 -99.5 35t-73.5 36 l-29 16v0zM512 750q79 -47 130.5 -63t101.5 -28q-5 -72 -16 -143q-12 -71 -38 -137.5t-69 -124.5q-42 -59 -109 -105v601z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_striker.svg
+++ b/public/assets/icons/white/role_striker.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_striker.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 824l-102 -205l68 -69v-443l34 -34l34 34v443l68 69zM847 652l-166 -157l41 -88l-94 -257l21 -43l43 20l94 257l87 40zM177 652l-26 -228l87 -40l94 -257l43 -20l21 43l-93 257l40 88z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_support.svg
+++ b/public/assets/icons/white/role_support.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_support.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M157 428l355 355l355 -355l-96 -97l-259 259l-259 -259zM283 199l229 229l229 -229l-48 -48l-181 180l-181 -180z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/role_tank.svg
+++ b/public/assets/icons/white/role_tank.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="role_tank.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 824l-29 -16t-73.5 -35.5t-99.5 -35.5q-54 -16 -105 -16l2 -30t6 -73t10 -90q7 -47 16 -80q17 -63 40 -125t62 -114q33 -43 76.5 -77t94.5 -59q51 25 94.5 59t76.5 77q39 52 62 114t40 125q9 33 15 80q7 47 11 90t6 73l2 30q-51 0 -105 16q-55 16 -99.5 35t-73.5 36 l-29 16v0zM512 750q79 -47 130.5 -63t101.5 -28q-5 -72 -16 -143q-12 -71 -38 -137.5t-69 -124.5q-42 -59 -109 -105v601z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/save.svg
+++ b/public/assets/icons/white/save.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="save.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-296 -170v-342l296 -170l296 170v342zM276 585h472l-236 -410l-118 205zM512 516q-28 0 -48 -20t-20 -48v0v0v0v0v0q0 -28 20 -48t48 -20v0q28 0 48 20t20 48v0v0v0v0v0q0 28 -20 48t-48 20v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/sensor.svg
+++ b/public/assets/icons/white/sensor.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="sensor.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M507 789q-60 -1 -118.5 -21t-108.5 -59q-38 -30 -67 -68q-28 -37 -46 -80t-26 -89q-7 -46 -3 -92h69q-9 78 21 151.5t95 124.5q40 32 88 48t97 17t97 -14q48 -16 90 -47q34 -25 59 -56q25 -32 40.5 -68.5t21.5 -76.5q6 -39 1 -79h69q4 48 -4 95t-27 90.5t-49 81.5 q-30 39 -70 68q-51 38 -110 56.5t-119 17.5v0zM510 653q-38 -1 -75.5 -13.5t-69.5 -37.5q-52 -40 -75 -100t-14 -122h69q-10 47 6.5 92.5t55.5 75.5q46 36 104 36.5t104 -34.5q40 -30 57 -76.5t7 -93.5h69q9 63 -15 123.5t-76 100.5q-33 25 -70.5 37t-76.5 12v0zM512 516 q-42 0 -72 -30t-30 -72q0 -34 19.5 -61t52.5 -37v-107l-72 -68v-34h204v34l-72 68v107q33 10 52.5 37t19.5 61q0 42 -30 72t-72 30v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/shield_outline.svg
+++ b/public/assets/icons/white/shield_outline.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg1"
+   sodipodi:docname="shield_outline.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="33.583333"
+     inkscape:cx="12"
+     inkscape:cy="11.985112"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
+     id="path1"
+     style="fill:#ffffff" />
+</svg>

--- a/public/assets/icons/white/ship.svg
+++ b/public/assets/icons/white/ship.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="ship.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M853 789l-170 -68l-103 -68v-34l-82 -55l-20 21v34h-273l-68 -34l170 -103h34l21 -20l-21 -48l30 -52l164 143h34v-34l-143 -164l52 -30l48 21l20 -21v-34l103 -170l34 68v273h-34l-21 20l55 82h34l68 103l68 170v0zM273 277l-102 -170l170 102v68h-68v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/size_1.svg
+++ b/public/assets/icons/white/size_1.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="size_1.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M527 847l380 -219v-439l-380 -220l-380 220v439zM490 425h147v34h-99l99 124v32h-145v-34h95l-97 -122v-34zM804 615h-139v-190h144v34h-105v49h92v33h-92v40h100v34zM427 425h39v190h-39v-190zM245 484q0 -15 5.5 -26.5t15.5 -20.5q11 -8 25.5 -12.5t33.5 -4.5 q18 0 32 4.5t24 13.5q10 8 15 19t5 24q0 12 -4.5 22t-12.5 16q-6 5 -14 8.5t-19 5.5l-33 8q-9 2 -15 4t-9 4q-5 2 -7 6t-2 9q0 6 2 10t7 7q4 3 10.5 4.5t13.5 1.5t13 -1t10 -3q7 -4 11 -10t4 -15h38q0 16 -5.5 27.5t-16.5 18.5q-10 8 -23 12t-28 4q-18 0 -31.5 -4t-22.5 -12 q-10 -9 -14.5 -19.5t-4.5 -23.5q0 -14 5 -24t14 -17q6 -4 16 -7.5t25 -6.5l20 -5q9 -2 15.5 -4t10.5 -5q4 -2 6 -6t2 -8q0 -8 -4 -13.5t-12 -8.5q-5 -2 -10.5 -2.5t-12.5 -0.5q-12 0 -20 3t-13 8q-3 4 -4.5 8.5t-2.5 11.5h-38zM516 291v-129h37v186h-30q0 -1 -0.5 -3 t-1.5 -4q-1 -4 -3 -7.5t-4 -5.5q-3 -4 -7.5 -6.5t-10.5 -3.5q-3 -1 -9.5 -1.5t-14.5 -0.5v-25h44z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/size_2.svg
+++ b/public/assets/icons/white/size_2.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="size_2.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M730 347l3 -2v-250l-217 -126l-217 126v250v1l-217 125v251l217 125l215 -124l215 124l217 -125v-251zM232 484q0 -15 5.5 -26.5t16.5 -20.5q10 -8 24.5 -12.5t33.5 -4.5q18 0 32 4.5t24 13.5q10 8 15 19t5 24q0 12 -4.5 22t-12.5 16q-6 5 -14 8.5t-19 5.5l-32 8 q-10 2 -16 4t-9 4q-4 2 -6.5 6t-2.5 9q0 6 2.5 10t6.5 7q5 3 11 4.5t14 1.5q6 0 12 -1t11 -3q7 -4 10.5 -10t4.5 -15h38q-1 16 -6.5 27.5t-16.5 18.5q-10 8 -23 12t-28 4q-18 0 -31.5 -4t-22.5 -12q-9 -9 -14 -19.5t-5 -23.5q0 -14 5 -24t15 -17q5 -4 15.5 -7.5t24.5 -6.5 l21 -5q8 -2 14.5 -4t10.5 -5q4 -2 6.5 -6t2.5 -8q0 -8 -4.5 -13.5t-12.5 -8.5q-4 -2 -10 -2.5t-13 -0.5q-11 0 -19.5 3t-13.5 8q-2 4 -4 8.5t-3 11.5h-38zM414 425h39v190h-39v-190zM477 425h147v34h-99l99 124v32h-145v-34h96l-98 -122v-34zM791 615h-139v-190h144v34h-105 v49h92v33h-92v40h100v34zM577 162v32h-82q2 3 4 5.5t5 4.5q2 3 7 6.5t12 8.5l14 10q10 7 16.5 12.5t10.5 11.5q6 8 9 17t3 20q0 13 -4 24t-13 19t-20.5 12t-26.5 4q-19 0 -32 -7t-20 -21q-4 -7 -6 -16.5t-3 -21.5h36q0 8 1 13.5t3 9.5q3 6 8.5 9t14.5 3q6 0 10.5 -2t7.5 -5 q4 -4 5.5 -9t1.5 -11q0 -7 -3 -14t-9 -13q-3 -4 -11.5 -10.5t-20.5 -15.5q-15 -10 -24 -20t-13 -19t-6.5 -18t-2.5 -19h128z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/size_3.svg
+++ b/public/assets/icons/white/size_3.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="size_3.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M693 700h170l84 -146l-84 -147l84 -147l-84 -147h-167l-83 -144h-169l-84 146l-2 -3h-169l-85 147l84 146h-2l-84 146l84 147h170l-2 3l85 146h169zM243 484q0 -15 5 -26.5t16 -20.5q11 -8 25.5 -12.5t32.5 -4.5t32.5 4.5t23.5 13.5q10 8 15 19t5 24q0 12 -4 22t-13 16 q-5 5 -13 8.5t-19 5.5l-33 8q-9 2 -15.5 4t-8.5 4q-5 2 -7 6t-2 9q0 6 2 10t7 7q4 3 10.5 4.5t13.5 1.5t13 -1t10 -3q7 -4 11 -10t4 -15h38q0 16 -5.5 27.5t-16.5 18.5q-11 8 -23.5 12t-27.5 4q-18 0 -31.5 -4t-23.5 -12q-9 -9 -13.5 -19.5t-4.5 -23.5q0 -14 5 -24t14 -17 q6 -4 16 -7.5t25 -6.5l20 -5q9 -2 15.5 -4t10.5 -5q4 -2 6 -6t2 -8q0 -8 -4 -13.5t-12 -8.5q-5 -2 -10.5 -2.5t-12.5 -0.5q-12 0 -20 3t-13 8q-3 4 -4.5 8.5t-2.5 11.5h-38zM425 425h39v190h-39v-190zM487 425h148v34h-100l100 124v32h-145v-34h95l-98 -122v-34zM802 615 h-139v-190h143v34h-105v49h93v33h-93v40h101v34zM458 219q1 -11 3 -20t6 -16q8 -13 22 -19.5t33 -6.5q16 0 28.5 4.5t20.5 13.5t12 19.5t4 22.5q0 11 -3.5 20t-10.5 15q-4 5 -8 7t-6 2q3 1 6.5 3.5t6.5 6.5q5 5 7 12t2 15q0 12 -4 21.5t-12 16.5q-8 6 -19 9.5t-24 3.5 q-7 0 -13 -0.5t-11 -2.5t-9.5 -4.5t-7.5 -5.5q-5 -5 -8.5 -10t-6.5 -10q-2 -7 -3 -13.5t-1 -13.5h34q0 7 1.5 12.5t4.5 9.5t7.5 6.5t11.5 2.5q5 0 9.5 -2t7.5 -5q3 -4 5 -8t2 -10q0 -8 -3.5 -13.5t-9.5 -7.5q-3 -2 -9.5 -3t-15.5 -1v-26q10 0 16.5 -1t10.5 -3q8 -3 11.5 -9 t3.5 -15q0 -7 -2 -12.5t-6 -8.5q-4 -4 -8.5 -6t-10.5 -2q-9 0 -15 3.5t-9 10.5q-2 3 -3 8t-1 10h-36z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/size_4.svg
+++ b/public/assets/icons/white/size_4.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="size_4.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M622 784l108 63l111 -63v-128v0l110 -64v-127l-109 -63l2 -1v-127l-111 -64v0v-127l-110 -64l-108 63l-109 -63l-110 64v127l-110 63v127l-2 -1l-111 63v128l110 63l-1 1v127l110 64l110 -64v3l111 63zM230 484q0 -15 5.5 -26.5t16.5 -20.5q10 -8 24.5 -12.5t33.5 -4.5 q18 0 32 4.5t24 13.5q10 8 15 19t5 24q0 12 -4.5 22t-12.5 16q-6 5 -14 8.5t-18 5.5l-33 8q-10 2 -16 4t-9 4q-4 2 -6.5 6t-2.5 9q0 6 2.5 10t6.5 7q5 3 11 4.5t14 1.5q7 0 12.5 -1t10.5 -3q7 -4 10.5 -10t4.5 -15h38q-1 16 -6.5 27.5t-15.5 18.5q-11 8 -24 12t-28 4 q-17 0 -31 -4t-23 -12q-9 -9 -13.5 -19.5t-4.5 -23.5q0 -14 4.5 -24t14.5 -17q5 -4 15.5 -7.5t25.5 -6.5l20 -5q8 -2 14.5 -4t10.5 -5q5 -2 7 -6t2 -8q0 -8 -4.5 -13.5t-12.5 -8.5q-4 -2 -10 -2.5t-13 -0.5q-11 0 -19.5 3t-13.5 8q-2 4 -4 8.5t-3 11.5h-38zM412 425h39v190 h-39v-190zM475 425h147v34h-99l99 124v32h-145v-34h96l-98 -122v-34zM789 615h-139v-190h144v34h-105v49h92v33h-92v40h100v34zM577 231h-21v116h-42l-68 -113v-32h74v-40h36v40h21v29zM473 231l47 80v-80h-47z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/size_half.svg
+++ b/public/assets/icons/white/size_half.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="size_half.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M907 180l-395 -227l-395 227v456l395 228l395 -228v-456zM512 830l-365 -211v-422l365 -211l366 211v422zM268 497q1 -7 3 -11.5t4 -8.5q5 -5 13.5 -8t20.5 -3q7 0 12.5 0.5t9.5 2.5q9 3 13 8.5t4 13.5q0 4 -2 8t-6 6q-4 3 -10.5 5t-15.5 4l-20 5q-15 3 -25.5 6.5 t-15.5 7.5q-10 7 -14.5 17t-4.5 24q0 13 4.5 23.5t13.5 18.5q9 9 23 13t32 4q15 0 27.5 -4t23.5 -12q10 -8 15.5 -19.5t6.5 -26.5h-38q-1 9 -4.5 15t-10.5 10q-5 2 -10.5 3t-12.5 1q-8 0 -14 -1.5t-11 -4.5q-4 -3 -6.5 -7t-2.5 -10q0 -5 2.5 -9t6.5 -6q3 -2 9.5 -4t15.5 -4 l33 -8q10 -2 18.5 -5.5t13.5 -8.5q9 -6 13 -16t4 -22q0 -13 -5 -24t-15 -19q-10 -9 -24 -13.5t-32 -4.5t-33 4.5t-25 12.5q-11 9 -16 20.5t-5 26.5h37v0zM412 628h40v-190h-40v190zM475 472l98 122h-95v34h144v-32l-99 -124h100v-34h-148v34v0zM789 594h-100v-40h92v-33h-92 v-49h105v-34h-143v190h138v-34v0zM348 304v24q8 1 14 1.5t10 1.5q5 1 9.5 3.5t8.5 6.5q2 2 4 5.5t3 7.5q1 2 1 4v3h31v-186h-38v129h-43v0zM535 370h30l-73 -195h-31zM557 175q0 10 2.5 19t6.5 18t13 19t24 20q12 9 20.5 15.5t12.5 10.5q5 6 8 13t3 14q0 6 -1.5 11t-5.5 8 q-3 4 -7.5 6t-10.5 2q-9 0 -14.5 -3t-8.5 -9q-2 -4 -3 -9.5t-1 -13.5h-36q1 12 3 21.5t6 16.5q7 14 20 21t32 7q15 0 26.5 -4t20.5 -12t13 -19t4 -25q0 -10 -3 -19t-9 -17q-4 -6 -10.5 -12t-16.5 -12l-14 -10q-7 -5 -12 -8.5t-7 -6.5q-3 -2 -5 -4.5t-4 -5.5h82v-32h-128v0z "
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/skill.svg
+++ b/public/assets/icons/white/skill.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="skill.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789q-71 0 -133 -27q-62 -26 -108.5 -72.5t-72.5 -108.5q-27 -62 -27 -133q0 -70 27 -133q26 -62 72.5 -108.5t108.5 -72.5q62 -27 133 -27q70 0 133 27q62 26 108.5 72.5t72.5 108.5q27 63 27 133q0 71 -27 133q-26 62 -72.5 108.5t-108.5 72.5q-63 27 -133 27v0z M512 721q57 0 106 -21q50 -22 87 -59t59 -86q21 -50 21 -107t-21 -106q-22 -50 -59 -87t-87 -59q-49 -21 -106 -21t-106 21q-50 22 -87 59t-59 87q-21 49 -21 106t21 107q22 49 59 86t87 59q49 21 106 21zM512 619l-50 -102l-112 -16l81 -79l-19 -112l100 53l100 -53 l-19 112l81 79l-112 16z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/spikes.svg
+++ b/public/assets/icons/white/spikes.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="spikes.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 928q-9 -77 -31 -140t-35 -109q-13 -4 -25.5 -9t-24.5 -12q-42 23 -102.5 52t-120.5 77q48 -60 77 -120.5t52 -102.5q-7 -12 -12 -24.5t-9 -25.5q-46 -13 -109 -35t-140 -31q77 -9 140 -31t109 -35q4 -13 9 -25.5t12 -24.5q-23 -42 -52 -102.5t-77 -120.5 q60 48 120.5 77t102.5 52q12 -7 24.5 -12t25.5 -9q13 -46 35 -109t31 -140q9 77 31 140t35 109q13 4 25.5 9t24.5 12q42 -23 102.5 -52t120.5 -77q-48 60 -77 120.5t-52 102.5q7 12 12 24.5t9 25.5q46 13 109 35t140 31q-77 9 -140 31t-109 35q-4 13 -9 25.5t-12 24.5 q23 42 52 102.5t77 120.5q-60 -48 -120.5 -77t-102.5 -52q-12 7 -24.5 12t-25.5 9q-13 46 -35 109t-31 140zM512 568q25 0 47 -9t38 -26q17 -16 26 -38t9 -47t-9 -47t-26 -38q-16 -17 -38 -26t-47 -9t-47 9t-38 26q-17 16 -26 38t-9 47t9 47t26 38q16 17 38 26t47 9z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/squad.svg
+++ b/public/assets/icons/white/squad.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="squad.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 723q-23 0 -39 -16t-16 -39v0q0 -23 16 -39.5t39 -16.5v0q23 0 39 16.5t16 39.5v0q0 23 -16 39t-39 16v0v0zM349 644q-25 0 -43 -18t-18 -44v0v0v0q0 -25 18 -43t43 -18v0v0v0q26 0 44 18t18 43v0v0v0q0 26 -18 44t-44 18v0v0v0zM675 644v0v0q-26 0 -44 -18t-18 -44 v0v0v0q0 -25 18 -43t44 -18v0v0v0q25 0 43 18t18 43v0v0v0q0 26 -18 44t-43 18v0v0zM512 551q-28 0 -48 -20t-20 -49v0q0 -28 20 -48t48 -20v0q28 0 48 20t20 48v0q0 29 -20 49t-48 20v0zM177 548q-29 0 -49 -20t-20 -49v0q0 -28 20 -48t49 -20v0q28 0 48 20t20 48v0 q0 29 -20 49t-48 20v0zM847 548q-28 0 -48 -20t-20 -49v0q0 -28 20 -48t48 -20v0q29 0 49 20t20 48v0q0 29 -20 49t-49 20v0zM328 443q-31 0 -53.5 -22t-22.5 -54v0v0v0v0v0q0 -31 22.5 -53.5t53.5 -22.5v0v0v0q31 0 53.5 22.5t22.5 53.5v0v0v0v0v0q0 32 -22.5 54t-53.5 22 v0v0v0zM696 443v0v0q-31 0 -53.5 -22t-22.5 -54v0v0v0v0v0q0 -31 22.5 -53.5t53.5 -22.5v0v0v0q31 0 53.5 22.5t22.5 53.5v0v0v0v0v0q0 32 -22.5 54t-53.5 22v0zM512 339v0v0q-35 0 -59.5 -24.5t-24.5 -59.5v0v0v0q0 -35 24.5 -59.5t59.5 -24.5v0v0v0v0v0q35 0 59.5 24.5 t24.5 59.5v0v0v0q0 35 -24.5 59.5t-59.5 24.5v0v0v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/structure.svg
+++ b/public/assets/icons/white/structure.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="structure.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 838l390 -390l-390 -390l-390 390zM512 155l293 293l-293 293l-293 -293zM512 653l-34 -34v-342l34 -34l34 34v342zM717 448l-34 34h-342l-34 -34l34 -34h342z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/sword_array.svg
+++ b/public/assets/icons/white/sword_array.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="sword_array.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M404 903q-13 0 -22.5 -9.5t-9.5 -23.5q0 -13 9 -22.5t23 -9.5q6 0 11.5 2t9.5 5l117 -43l-21 -60l35 -13l9 27l320 -116l104 19l-66 82l-320 117l9 27l-35 12l-22 -60l-120 44q-3 10 -11.5 16t-19.5 6v0zM590 823l248 -90l22 -27l-30 -7l-252 92l12 32v0zM327 761 q-14 0 -23.5 -9.5t-9.5 -23.5q0 -13 9.5 -22.5t23.5 -9.5q3 0 5.5 0.5t4.5 0.5v0l105 -74l-36 -53l30 -21l16 23l279 -195l106 -8l-42 96l-280 196l16 23l-31 22l-36 -53l-105 73v1.5v0.5q0 14 -9.5 23.5t-22.5 9.5v0zM221 633q-13 0 -22.5 -9.5t-9.5 -23.5q0 -13 9.5 -22.5 t22.5 -9.5h3h3l74 -88l-49 -41l24 -29l21 19l220 -262l99 -33l-16 104l-219 260l21 19l-24 28l-49 -41l-76 91q1 1 1 2.5v2.5q0 14 -9.5 23.5t-23.5 9.5v0zM493 630l215 -150l14 -31l-31 2l-217 152l19 27v0zM86 545q-14 0 -23.5 -9.5t-9.5 -23.5q0 -11 7 -20t18 -11 l48 -104l-58 -27l16 -33l26 12l144 -310l87 -58l11 105l-144 309l26 11l-16 34l-58 -27l-47 101q2 4 3.5 8.5t1.5 10.5q0 13 -9.5 22.5t-22.5 9.5v0zM352 474l168 -200l6 -33l-31 10l-169 202l26 21v0zM174 359l110 -235l-3 -34l-27 17l-110 237l30 15v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/system.svg
+++ b/public/assets/icons/white/system.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="system.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M580 789l-61 -61l-51 51l-48 -48l51 -51l-71 -71l-52 51l-48 -48l51 -52l-71 -71l-51 51l-48 -48l51 -51l-61 -61v-34l239 -239h34l61 61l51 -51l48 48l-51 51l72 71l51 -51l48 48l-51 52l71 71l51 -51l48 48l-51 51l61 61v34l-239 239h-34zM580 619l103 -103l-239 -239 l-103 103z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/system_point.svg
+++ b/public/assets/icons/white/system_point.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="system_point.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M478 755l-273 -273v-68l273 -273h68l273 273v68l-273 273h-68zM478 687h68v-102l103 -103h102v-68h-102l-103 -103v-102h-68v102l-103 103h-102v68h102l103 103v102z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/tag.svg
+++ b/public/assets/icons/white/tag.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   preserveAspectRatio="xMidYMid meet"
+   viewBox="0 0 24 24"
+   style="-ms-transform: rotate(360deg); -webkit-transform: rotate(360deg); transform: rotate(360deg);"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="tag.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="33.583333"
+     inkscape:cx="12"
+     inkscape:cy="11.985112"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M17.63 5.84C17.27 5.33 16.67 5 16 5H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h11c.67 0 1.27-.34 1.63-.85L22 12l-4.37-6.16z"
+     fill="#currentColor"
+     id="path1"
+     style="-ms-transform:rotate(360deg);-webkit-transform:rotate(360deg);transform:rotate(360deg);fill:#ffffff" />
+</svg>

--- a/public/assets/icons/white/talent.svg
+++ b/public/assets/icons/white/talent.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="talent.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 707l-156 -157l156 -156l156 156zM307 502l-156 -156l156 -157l147 147v0l10 10zM717 502l-157 -156l10 -10v0l147 -147l156 157z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/tech_full.svg
+++ b/public/assets/icons/white/tech_full.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="tech_full.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M225 721l-88 -88v-370l88 -88h574l89 88v370l-89 88h-574zM311 609l161 -161l-161 -161l-48 49l112 112l-112 112zM582 597l64 -24l-102 -273l-64 23zM719 597l64 -24l-103 -273l-63 23z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/tech_quick.svg
+++ b/public/assets/icons/white/tech_quick.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="tech_quick.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M225 721l-10 -10l-79 -78v-370l89 -88h574l88 88v370l-88 88h-574zM253 653h518l48 -48v-314l-48 -48h-518l-48 48v314zM311 609l-48 -49l112 -112l-112 -112l48 -49l161 161zM582 597l-102 -274l64 -23l102 273zM719 597l-103 -274l64 -23l103 273z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/threat.svg
+++ b/public/assets/icons/white/threat.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="threat.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 651l77 -77l113 113l-44 44l48 48l137 -136l-48 -48l-44 44l-114 -113l78 -78l-78 -77l114 -114l44 45l48 -49l-137 -136l-48 48l44 44l-113 113l-77 -77l-77 77l-114 -113l44 -44l-48 -48l-136 136l48 48l44 -44l114 114l-78 77l78 77l-114 114l-44 -44l-48 48 l136 136l48 -48l-44 -44l114 -114zM512 309l139 139l-139 139l-139 -139z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/thrown.svg
+++ b/public/assets/icons/white/thrown.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="thrown.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M853 619q0 -71 -50 -121t-120 -50v0q-71 0 -121 50t-50 121v0q0 70 50 120t121 50v0q70 0 120 -50t50 -120v0v0zM147 142l100 101l60 -60l-101 -101l-59 60v0zM274 270l100 100l60 -60l-100 -100zM399 395l101 100l60 -59l-101 -101l-60 60v0z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>

--- a/public/assets/icons/white/trait.svg
+++ b/public/assets/icons/white/trait.svg
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 -64 1024 1024"
+   width="512"
+   height="512"
+   id="svg1"
+   sodipodi:docname="trait.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.5742188"
+     inkscape:cx="256"
+     inkscape:cy="255.68238"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <g
+     transform="matrix(1 0 0 -1 0 960)"
+     id="g1"
+     style="fill:#ffffff">
+    <path
+       fill="currentColor"
+       d="M512 789l-118 -68l34 -59l84 48l84 -48l34 59zM335 687l-119 -68v-137h69v97l84 49zM689 687l-34 -59l84 -49v-97h69v137zM216 414v-137l119 -68l34 59l-84 49v97h-69zM739 414v-97l-84 -49l34 -59l119 68v137h-69zM428 234l-34 -59l118 -68l118 68l-34 59l-84 -49z M512 585l118 -69v-136l-118 -69l-118 69v136z"
+       id="path1"
+       style="fill:#ffffff" />
+  </g>
+</svg>


### PR DESCRIPTION
For all icons currently available in black, add a white version in icons\white.
Also, for your consideration, added corepower.svg in both black and white.