### PR TITLE
fix: Add grid config for v12 to system manifest

### DIFF
--- a/public/system.json
+++ b/public/system.json
@@ -53,6 +53,10 @@
     }
   ],
   "socket": true,
+  "grid": {
+    "distance": 1,
+    "units": ""
+  },
   "gridDistance": 1,
   "gridUnits": "",
   "primaryTokenAttribute": "",


### PR DESCRIPTION
This addresses deprecation warnings appearing in Foundry v12 related to this item from:

https://github.com/Eranziel/foundryvtt-lancer/issues/650

> * [ ]  Update manifest grid configuration - [V12 System manifest schema changes foundryvtt/foundryvtt#9999](https://github.com/foundryvtt/foundryvtt/issues/9999)

I assume we want to keep the old `gridDistance` and `gridUnits` for now for Foundry v11 support?

## Testing

Verified that the deprecation warnings (for `gridDistance` and `gridUnits`) disappeared after adding this (in Foundry v12).