### PR TITLE
feat(macros): add optional actorPermLevel change to Scans

### DIFF
--- a/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
+++ b/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
@@ -150,9 +150,9 @@ ownership:
   2a2IgZ2kiAqXSGqu: 3
 _stats:
   systemId: lancer
-  systemVersion: 2.0.0
-  coreVersion: "11.315"
+  systemVersion: 2.1.5
+  coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1717340495229
-  lastModifiedBy: RyAORVJNmdo1gq2Z
-_key: "!macros!3KPsYon0LoANWX54"
+  modifiedTime: 1720297619727
+  lastModifiedBy: VTqqjv3vCWDxBIi5
+_key: '!macros!3KPsYon0LoANWX54'

--- a/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
+++ b/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
@@ -6,7 +6,7 @@ img: systems/lancer/assets/icons/macro-icons/tech_quick.svg
 scope: global
 command: |-
   let targets = Array.from(game.user.targets);
-
+  const actorPermissionLevel = -1
   function sort_features(a, b) {
     return b.system.origin.base - a.system.origin.base;
   }
@@ -56,6 +56,11 @@ command: |-
 
   targets.forEach((target) => {
     let actor = target.actor;
+    if (actorPermissionLevel >= 0) {
+      const actorId = actor.system.parent._id
+      const parentActor = game.actors.get(actorId)
+      parentActor.update({ ownership: { default: actorPermissionLevel } });
+    }
     let items = actor.items;
     let hase_table_html = `
   <table>

--- a/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
+++ b/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
@@ -4,12 +4,21 @@ type: script
 author: 2a2IgZ2kiAqXSGqu
 img: systems/lancer/assets/icons/macro-icons/tech_quick.svg
 scope: global
-command: |-
+command: >-
   let targets = Array.from(game.user.targets);
-  const actorPermissionLevel = -1;
+
+
+  //actorPermissionLevel - This sets the permission level for the parent actor
+  of a token (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED,
+  OBSERVER, or OWNER). If set to `null`, no change is made.
+
+  const actorPermissionLevel = null;
+
+
   function sort_features(a, b) {
     return b.system.origin.base - a.system.origin.base;
   }
+
 
   function construct_features(items, origin) {
     let sc_list = ``;
@@ -38,6 +47,7 @@ command: |-
     return sc_list;
   }
 
+
   function construct_templates(items) {
     let sc_templates = ``;
     if (!items || items.length == 0) {
@@ -52,9 +62,10 @@ command: |-
     return sc_templates;
   }
 
+
   targets.forEach(target => {
     let actor = target.actor;
-    if (actorPermissionLevel >= 0) {
+    if (actorPermissionLevel !== null) {
       const actorId = actor.system.parent._id;
       const parentActor = game.actors.get(actorId);
       parentActor.update({ ownership: { default: actorPermissionLevel } });
@@ -149,6 +160,6 @@ _stats:
   systemVersion: 2.1.5
   coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1720298842906
+  modifiedTime: 1720304531394
   lastModifiedBy: VTqqjv3vCWDxBIi5
 _key: '!macros!3KPsYon0LoANWX54'

--- a/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
+++ b/src/packs/core_macros/Scan_3KPsYon0LoANWX54.yml
@@ -6,7 +6,7 @@ img: systems/lancer/assets/icons/macro-icons/tech_quick.svg
 scope: global
 command: |-
   let targets = Array.from(game.user.targets);
-  const actorPermissionLevel = -1
+  const actorPermissionLevel = -1;
   function sort_features(a, b) {
     return b.system.origin.base - a.system.origin.base;
   }
@@ -14,10 +14,8 @@ command: |-
   function construct_features(items, origin) {
     let sc_list = ``;
     sc_list += `<p>${origin}</p>`;
-    let sc_features = items
-      .filter((f) => f.system.origin.name === origin)
-      .sort(sort_features);
-    sc_features.forEach((i) => {
+    let sc_features = items.filter(f => f.system.origin.name === origin).sort(sort_features);
+    sc_features.forEach(i => {
       let sc_name = ``;
       let sc_desc = ``;
       if (i.system.origin.name === "EXOTIC" && !i.system.origin.base) {
@@ -45,7 +43,7 @@ command: |-
     if (!items || items.length == 0) {
       sc_templates += "<p>NONE</p>";
     } else {
-      items.forEach((i) => {
+      items.forEach(i => {
         sc_templates += `<p>${i.name}</p>`;
       });
     }
@@ -54,11 +52,11 @@ command: |-
     return sc_templates;
   }
 
-  targets.forEach((target) => {
+  targets.forEach(target => {
     let actor = target.actor;
     if (actorPermissionLevel >= 0) {
-      const actorId = actor.system.parent._id
-      const parentActor = game.actors.get(actorId)
+      const actorId = actor.system.parent._id;
+      const parentActor = game.actors.get(actorId);
       parentActor.update({ ownership: { default: actorPermissionLevel } });
     }
     let items = actor.items;
@@ -100,31 +98,29 @@ command: |-
     <tr>
       <td>${actor.system.size}</td>
       <td>${actor.system.activations || 1}</td>
-      <td>${actor.system.structure.value || 0}/${
-        actor.system.structure.max || 0
-      }</td>
+      <td>${actor.system.structure.value || 0}/${actor.system.structure.max || 0}</td>
       <td>${actor.system.stress.value || 0}/${actor.system.stress.max || 0}</td>
     </tr>
   </table>`;
     console.log("Scanning", target);
-    const classes = items.filter((i) => i.is_npc_class());
+    const classes = items.filter(i => i.is_npc_class());
     let sc_class = !classes || classes.length === 0 ? "NONE" : classes[0].name;
     let sc_tier = actor.system.tier;
-    const templates = items.filter((i) => i.is_npc_template());
+    const templates = items.filter(i => i.is_npc_template());
     let sc_templates = construct_templates(templates);
     let sc_list = ``;
-    const features = items.filter((i) => i.is_npc_feature());
+    const features = items.filter(i => i.is_npc_feature());
     if (!features || features.length === 0) {
       sc_list += "<p>NONE</p>";
     } else {
       let sc_origins = [];
-      features.forEach((f) => {
+      features.forEach(f => {
         let origin = f.system.origin.name;
         if (!sc_origins.includes(origin)) {
           sc_origins.push(origin);
         }
       });
-      sc_origins.forEach((origin) => {
+      sc_origins.forEach(origin => {
         sc_list += construct_features(features, origin);
       });
     }
@@ -153,6 +149,6 @@ _stats:
   systemVersion: 2.1.5
   coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1720297619727
+  modifiedTime: 1720298842906
   lastModifiedBy: VTqqjv3vCWDxBIi5
 _key: '!macros!3KPsYon0LoANWX54'

--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -64,7 +64,7 @@ command: >-
   of a token. This must be an integer between -1 and 3 where -1 is "No change",
   0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
 
-  const actorPermissionLevel = -1
+  const actorPermissionLevel = -1;
 
   //targets - Gets the data for your currently selected target(s) and stores it
   for later use. Do not change.
@@ -97,7 +97,7 @@ command: >-
   //findItemByType - To find specific items in the .item array.
 
   function findItemByType(array, itemType) {
-    return array.filter((item) => item.type === itemType);
+    return array.filter(item => item.type === itemType);
   }
 
 
@@ -114,14 +114,8 @@ command: >-
   function construct_features(items, origin) {
     let sc_list = ``;
     sc_list += `<p>${origin}</p>`;
-    let sc_features = items
-      .filter(
-        (f) =>
-          f.system.origin &&
-          f.system.origin.name === origin
-      )
-      .sort(sort_features);
-    sc_features.forEach((i) => {
+    let sc_features = items.filter(f => f.system.origin && f.system.origin.name === origin).sort(sort_features);
+    sc_features.forEach(i => {
       let sc_name = ``;
       let sc_desc = ``;
       if (i.system.origin.name == "EXOTIC" && !i.system.origin.base) {
@@ -148,14 +142,9 @@ command: >-
   function construct_weapons(items, origin, tier) {
     let sc_weapons = ``;
     let sc_features = items
-      .filter(
-        (i) =>
-          i.system.origin &&
-          i.system.origin.name === origin &&
-          i.system.type === "Weapon"
-      )
+      .filter(i => i.system.origin && i.system.origin.name === origin && i.system.type === "Weapon")
       .sort(sort_features);
-    sc_features.forEach((i) => {
+    sc_features.forEach(i => {
       let sc_name = ``;
       let sc_desc = ``;
       let sc_entry = ``;
@@ -167,8 +156,7 @@ command: >-
       }
       sc_weapons += `<table>`;
       if (i.system.origin.name == "EXOTIC" && !i.system.origin.base) {
-        sc_name =
-          '<tr><th><code class="horus--subtle">UNKNOWN EXOTIC WEAPON</code></th></tr>';
+        sc_name = '<tr><th><code class="horus--subtle">UNKNOWN EXOTIC WEAPON</code></th></tr>';
         sc_desc = "<tr><td>???</td></tr>";
         sc_entry = sc_name + sc_desc;
       } else {
@@ -178,24 +166,18 @@ command: >-
         sc_desc += `<td>+${i.system.attack_bonus[tier - 1]} ATTACK</td>`;
         if (i.system.accuracy[tier - 1]) {
           let acc = i.system.accuracy[tier - 1];
-          sc_accuracy = `${acc > 0 ? "+" : ""}${acc} ${
-            acc > 0 ? "ACCURACY" : "DIFFICULTY"
-          }`;
+          sc_accuracy = `${acc > 0 ? "+" : ""}${acc} ${acc > 0 ? "ACCURACY" : "DIFFICULTY"}`;
         }
         sc_desc += `<td>${sc_accuracy}</td>`;
         if (i.system.range.length > 0) {
-          i.system.range.forEach(
-            (r) => (sc_range += r.type + " " + r.val + "&nbsp&nbsp&nbsp")
-          );
+          i.system.range.forEach(r => (sc_range += r.type + " " + r.val + "&nbsp&nbsp&nbsp"));
         }
         sc_desc += `<td>${sc_range}</td>`;
         if (i.system.damage.length > 0) {
-          i.system.damage[tier - 1].forEach(
-            (d) => (sc_damage += d.val + " " + d.type + "&nbsp&nbsp&nbsp")
-          );
+          i.system.damage[tier - 1].forEach(d => (sc_damage += d.val + " " + d.type + "&nbsp&nbsp&nbsp"));
         }
         sc_desc += `<td>${sc_damage}</td>`;
-        if (i.system.tags.some((t) => t.is_loading)) {
+        if (i.system.tags.some(t => t.is_loading)) {
           if (i.system.loaded) {
             sc_desc += `<td>LOADED</td>`;
           } else {
@@ -219,9 +201,7 @@ command: >-
         }
         if (i.system.tags.length > 0) {
           sc_desc += `<tr><td colspan="6">Tags: `;
-          sc_desc += i.system.tags
-            .map((t) => `${t.name.replace("{VAL}", t.val)}`)
-            .join(", ");
+          sc_desc += i.system.tags.map(t => `${t.name.replace("{VAL}", t.val)}`).join(", ");
           sc_desc += `</td></tr>`;
         }
         sc_entry += sc_desc;
@@ -242,7 +222,7 @@ command: >-
     if (!sc_temp || sc_temp.length == 0) {
       sc_templates += "<p>NONE</p>";
     } else {
-      sc_temp.forEach((i) => {
+      sc_temp.forEach(i => {
         let sc_entry = `<p>${i.name}</p>`;
         sc_templates += sc_entry;
       });
@@ -272,11 +252,11 @@ command: >-
 
   // Create the journal for each targeted token
 
-  targets.forEach(async (target) => {
+  targets.forEach(async target => {
     let actor = target.actor;
     if (actorPermissionLevel >= 0) {
-      const actorId = actor.system.parent._id
-      const parentActor = game.actors.get(actorId)
+      const actorId = actor.system.parent._id;
+      const parentActor = game.actors.get(actorId);
       parentActor.update({ ownership: { default: actorPermissionLevel } });
     }
     console.log("Scanning target:", actor);
@@ -325,9 +305,7 @@ command: >-
     <tr>
       <td>${actor.system.size}</td>
       <td>${actor.system.activations || 1}</td>
-      <td>${actor.system.structure.value || 0}/${
-      actor.system.structure.max || 0
-    }</td>
+      <td>${actor.system.structure.value || 0}/${actor.system.structure.max || 0}</td>
       <td>${actor.system.stress.value || 0}/${actor.system.stress.max || 0}</td>
     </tr>
   </table> `;
@@ -343,14 +321,14 @@ command: >-
     } else {
       let sc_origins = [];
 
-      items.forEach((f) => {
+      items.forEach(f => {
         let origin = f.system.origin?.name;
         if (origin && !sc_origins.includes(origin)) {
           sc_origins.push(origin);
         }
       });
 
-      sc_origins.forEach((origin) => {
+      sc_origins.forEach(origin => {
         sc_list += construct_features(items, origin);
         sc_weapons += construct_weapons(items, origin, sc_tier);
       });
@@ -359,8 +337,7 @@ command: >-
     if (outputToChat) {
       ChatMessage.create({
         user: game.user._id,
-        content:
-          `<h2>Scan results: ${actor.name}</h2>
+        content: `<h2>Scan results: ${actor.name}</h2>
           <h3>Class: ${sc_class}, Tier ${sc_tier}</h3>
           ${hase_table_html}
           ${stat_table_html}
@@ -393,9 +370,7 @@ command: >-
 
     let scanEntry;
 
-    let matchingJournalEntries = journalFolder.contents.filter((e) =>
-      e.name.match(actor.name)
-    );
+    let matchingJournalEntries = journalFolder.contents.filter(e => e.name.match(actor.name));
 
     if (matchingJournalEntries.length == 1 && updateExisting === true) {
       console.log("Updating an existing scan");
@@ -410,8 +385,7 @@ command: >-
     } else {
       console.log("Creating a new scan");
       let scanCount = zeroPad(
-        journalFolder.contents.filter((e) => e.name.startsWith(nameTemplate))
-          .length + startingNumber,
+        journalFolder.contents.filter(e => e.name.startsWith(nameTemplate)).length + startingNumber,
         numberLength
       );
       scanObj.name = nameTemplate + scanCount + ` - ` + actor.name;
@@ -435,6 +409,6 @@ _stats:
   systemVersion: 2.1.5
   coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1720297593213
+  modifiedTime: 1720298820356
   lastModifiedBy: VTqqjv3vCWDxBIi5
 _key: '!macros!z0pdvwE0FitMzwRJ'

--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -5,9 +5,7 @@ author: jE81C9hyfb9evTbT
 img: systems/lancer/assets/icons/macro-icons/tech_quick.svg
 scope: global
 command: >-
-  //Sanity Check - Can this user even create folders and journal entries? Does
-  the folder journal folder exist?
-
+  //Sanity Check - Can this user even create folders and journal entries? Does the folder journal folder exist?
   if (JournalEntry.canUserCreate(game.user) == false) {
     ui.notifications.error(
       `${game.user.name} attempted to run SCAN to Journal but lacks proper permissions. Please correct and try again.`
@@ -15,96 +13,53 @@ command: >-
     return;
   }
 
-
   // ======================================================
-
   //Variables - Change these to control the macro
-
   // ======================================================
-
 
   // outputToChat - if set to true, also send the scan results to chat.
-
   const outputToChat = false;
-
-  //journalFolderName - The name, as displayed in foundry, of the folder you
-  want the journal entries to save to. Remember to enclose in quotes: 'example'
-
+  //journalFolderName - The name, as displayed in foundry, of the folder you want the journal entries to save to. Remember to enclose in quotes: 'example'
   const journalFolderName = "SCAN Database";
-
-  //nameTemplate - The text before the scan number and target name. Remember to
-  enclose in quotes: 'example'
-
+  //nameTemplate - The text before the scan number and target name. Remember to enclose in quotes: 'example'
   const nameTemplate = "SCAN: ";
-
-  //numberLength - The total length of the scan number, extra spaces are filled
-  with 0s. Setting this to 3, for example would produce scan number 001 on your
-  first scan. Integers only and no quotes.
-
+  //numberLength - The total length of the scan number, extra spaces are filled with 0s. Setting this to 3, for example would produce scan number 001 on your first scan. Integers only and no quotes.
   const numberLength = 3;
-
-  //startingNumber - If you want the scan number to start at something other
-  than 1 then change this. Integers only and no quotes.
-
+  //startingNumber - If you want the scan number to start at something other than 1 then change this. Integers only and no quotes.
   const startingNumber = 1;
-
-  //permissionLevel - This sets the default permission level of the scan entry.
-  This must be an integer between 0 and 3 where 0 is "None", 1 is "Limited", 2
-  is "Observer", and 3 is "Owner"
-
+  //permissionLevel - This sets the default permission level of the scan entry. This must be an integer between 0 and 3 where 0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
   const permissionLevel = 3;
-
-  //updateExisting - This macro will check if a scan journal entry exists and
-  update it, set this to false if you want it to create a new scan journal
-  entry.
-
+  //updateExisting - This macro will check if a scan journal entry exists and update it, set this to false if you want it to create a new scan journal entry.
   const updateExisting = true;
-
-  //targets - Gets the data for your currently selected target(s) and stores it
-  for later use. Do not change.
-
+  //actorPermissionLevel - This sets the permission level for the parent actor of a token. This must be an integer between -1 and 3 where -1 is "No change", 0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
+  const actorPermissionLevel = -1
+  //targets - Gets the data for your currently selected target(s) and stores it for later use. Do not change.
   let targets = Array.from(game.user.targets);
 
-
   // ===========================================================
-
   // DO NOT MODIFY BELOW HERE UNLESS YOU KNOW WHAT YOU'RE DOING
-
   // ===========================================================
 
-
   // ======================================================
-
   //Functions
-
   // ======================================================
 
-
-  //zeroPad - Adds a set number 0s to the fed number to produce a consistent
-  length number.
-
+  //zeroPad - Adds a set number 0s to the fed number to produce a consistent length number.
   function zeroPad(num, places) {
     return String(num).padStart(places, "0");
   }
 
-
   //findItemByType - To find specific items in the .item array.
-
   function findItemByType(array, itemType) {
     return array.filter((item) => item.type === itemType);
   }
 
-
   //sort_features - Sorts the feature list for the scanned target
-
   function sort_features(a, b) {
     return b.system.origin.base - a.system.origin.base;
   }
 
-
-  //construct_features - Builds out the list of selectable features for the
-  scanned target, includes support for exotics.
-
+  //construct_features - Builds out the list of selectable features for the scanned target, includes support for exotics.
   function construct_features(items, origin) {
     let sc_list = ``;
     sc_list += `<p>${origin}</p>`;
@@ -137,7 +92,6 @@ command: >-
     });
     return sc_list;
   }
-
 
   function construct_weapons(items, origin, tier) {
     let sc_weapons = ``;
@@ -226,9 +180,7 @@ command: >-
     return sc_weapons;
   }
 
-
   //construct_templates
-
   function construct_templates(items) {
     let templatefind = findItemByType(items, "npc_template");
     let sc_templates = ``;
@@ -244,11 +196,8 @@ command: >-
     return sc_templates;
   }
 
-
   // Find or create the Scans folder
-
   let journalFolder = game.folders.getName(journalFolderName);
-
   if (!journalFolder && journalFolderName.length > 0) {
     try {
       journalFolder = await Folder.create({
@@ -263,20 +212,21 @@ command: >-
     }
   }
 
-
   // Create the journal for each targeted token
-
   targets.forEach(async (target) => {
     let actor = target.actor;
+    if (actorPermissionLevel >= 0) {
+      const actorId = actor.system.parent._id
+      const parentActor = game.actors.get(actorId)
+      parentActor.update({ ownership: { default: actorPermissionLevel } });
+    }
     console.log("Scanning target:", actor);
     let items = actor.items;
     let hase_table_html = `
-  <p><img style="border: 3px dashed #000000; float: left; margin-right: 5px;
-  margin-left: 5px;" src="${
+  <p><img style="border: 3px dashed #000000; float: left; margin-right: 5px; margin-left: 5px;" src="${
       target.document.actor.img
     }" width="30%" height="30%" /></p>
   <div style="color: #000000; width: 65%; float: right; text-align: left;">
-
   <table>
     <tr>
       <th>HULL</th><th>AGI</th><th>SYS</th><th>ENG</th>

--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -5,7 +5,9 @@ author: jE81C9hyfb9evTbT
 img: systems/lancer/assets/icons/macro-icons/tech_quick.svg
 scope: global
 command: >-
-  //Sanity Check - Can this user even create folders and journal entries? Does the folder journal folder exist?
+  //Sanity Check - Can this user even create folders and journal entries? Does
+  the folder journal folder exist?
+
   if (JournalEntry.canUserCreate(game.user) == false) {
     ui.notifications.error(
       `${game.user.name} attempted to run SCAN to Journal but lacks proper permissions. Please correct and try again.`
@@ -13,53 +15,102 @@ command: >-
     return;
   }
 
+
   // ======================================================
+
   //Variables - Change these to control the macro
+
   // ======================================================
+
 
   // outputToChat - if set to true, also send the scan results to chat.
+
   const outputToChat = false;
-  //journalFolderName - The name, as displayed in foundry, of the folder you want the journal entries to save to. Remember to enclose in quotes: 'example'
+
+  //journalFolderName - The name, as displayed in foundry, of the folder you
+  want the journal entries to save to. Remember to enclose in quotes: 'example'
+
   const journalFolderName = "SCAN Database";
-  //nameTemplate - The text before the scan number and target name. Remember to enclose in quotes: 'example'
+
+  //nameTemplate - The text before the scan number and target name. Remember to
+  enclose in quotes: 'example'
+
   const nameTemplate = "SCAN: ";
-  //numberLength - The total length of the scan number, extra spaces are filled with 0s. Setting this to 3, for example would produce scan number 001 on your first scan. Integers only and no quotes.
+
+  //numberLength - The total length of the scan number, extra spaces are filled
+  with 0s. Setting this to 3, for example would produce scan number 001 on your
+  first scan. Integers only and no quotes.
+
   const numberLength = 3;
-  //startingNumber - If you want the scan number to start at something other than 1 then change this. Integers only and no quotes.
+
+  //startingNumber - If you want the scan number to start at something other
+  than 1 then change this. Integers only and no quotes.
+
   const startingNumber = 1;
-  //permissionLevel - This sets the default permission level of the scan entry. This must be an integer between 0 and 3 where 0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
+
+  //permissionLevel - This sets the default permission level of the scan entry.
+  This must be an integer between 0 and 3 where 0 is "None", 1 is "Limited", 2
+  is "Observer", and 3 is "Owner"
+
   const permissionLevel = 3;
-  //updateExisting - This macro will check if a scan journal entry exists and update it, set this to false if you want it to create a new scan journal entry.
+
+  //updateExisting - This macro will check if a scan journal entry exists and
+  update it, set this to false if you want it to create a new scan journal
+  entry.
+
   const updateExisting = true;
-  //actorPermissionLevel - This sets the permission level for the parent actor of a token. This must be an integer between -1 and 3 where -1 is "No change", 0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
+
+  //actorPermissionLevel - This sets the permission level for the parent actor
+  of a token. This must be an integer between -1 and 3 where -1 is "No change",
+  0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
+
   const actorPermissionLevel = -1
-  //targets - Gets the data for your currently selected target(s) and stores it for later use. Do not change.
+
+  //targets - Gets the data for your currently selected target(s) and stores it
+  for later use. Do not change.
+
   let targets = Array.from(game.user.targets);
 
+
   // ===========================================================
+
   // DO NOT MODIFY BELOW HERE UNLESS YOU KNOW WHAT YOU'RE DOING
+
   // ===========================================================
 
-  // ======================================================
-  //Functions
+
   // ======================================================
 
-  //zeroPad - Adds a set number 0s to the fed number to produce a consistent length number.
+  //Functions
+
+  // ======================================================
+
+
+  //zeroPad - Adds a set number 0s to the fed number to produce a consistent
+  length number.
+
   function zeroPad(num, places) {
     return String(num).padStart(places, "0");
   }
 
+
   //findItemByType - To find specific items in the .item array.
+
   function findItemByType(array, itemType) {
     return array.filter((item) => item.type === itemType);
   }
 
+
   //sort_features - Sorts the feature list for the scanned target
+
   function sort_features(a, b) {
     return b.system.origin.base - a.system.origin.base;
   }
 
-  //construct_features - Builds out the list of selectable features for the scanned target, includes support for exotics.
+
+  //construct_features - Builds out the list of selectable features for the
+  scanned target, includes support for exotics.
+
   function construct_features(items, origin) {
     let sc_list = ``;
     sc_list += `<p>${origin}</p>`;
@@ -92,6 +143,7 @@ command: >-
     });
     return sc_list;
   }
+
 
   function construct_weapons(items, origin, tier) {
     let sc_weapons = ``;
@@ -180,7 +232,9 @@ command: >-
     return sc_weapons;
   }
 
+
   //construct_templates
+
   function construct_templates(items) {
     let templatefind = findItemByType(items, "npc_template");
     let sc_templates = ``;
@@ -196,8 +250,11 @@ command: >-
     return sc_templates;
   }
 
+
   // Find or create the Scans folder
+
   let journalFolder = game.folders.getName(journalFolderName);
+
   if (!journalFolder && journalFolderName.length > 0) {
     try {
       journalFolder = await Folder.create({
@@ -212,7 +269,9 @@ command: >-
     }
   }
 
+
   // Create the journal for each targeted token
+
   targets.forEach(async (target) => {
     let actor = target.actor;
     if (actorPermissionLevel >= 0) {
@@ -223,10 +282,12 @@ command: >-
     console.log("Scanning target:", actor);
     let items = actor.items;
     let hase_table_html = `
-  <p><img style="border: 3px dashed #000000; float: left; margin-right: 5px; margin-left: 5px;" src="${
+  <p><img style="border: 3px dashed #000000; float: left; margin-right: 5px;
+  margin-left: 5px;" src="${
       target.document.actor.img
     }" width="30%" height="30%" /></p>
   <div style="color: #000000; width: 65%; float: right; text-align: left;">
+
   <table>
     <tr>
       <th>HULL</th><th>AGI</th><th>SYS</th><th>ENG</th>
@@ -365,15 +426,15 @@ folder: yxTxiLixDsbyThYC
 sort: 125000
 flags:
   combat-utility-belt:
-    macroTrigger: ""
+    macroTrigger: ''
 ownership:
   default: 0
   jE81C9hyfb9evTbT: 3
 _stats:
   systemId: lancer
-  systemVersion: 2.0.0
-  coreVersion: "11.315"
+  systemVersion: 2.1.5
+  coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1717341303401
-  lastModifiedBy: RyAORVJNmdo1gq2Z
-_key: "!macros!z0pdvwE0FitMzwRJ"
+  modifiedTime: 1720297593213
+  lastModifiedBy: VTqqjv3vCWDxBIi5
+_key: '!macros!z0pdvwE0FitMzwRJ'

--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -48,11 +48,11 @@ command: >-
 
   const startingNumber = 1;
 
-  //permissionLevel - This sets the default permission level of the scan entry.
-  This must be an integer between 0 and 3 where 0 is "None", 1 is "Limited", 2
-  is "Observer", and 3 is "Owner"
+  //permissionLevel - This sets the default permission level of the scan entry
+  (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED, OBSERVER, or
+  OWNER).
 
-  const permissionLevel = 3;
+  const permissionLevel = CONST.DOCUMENT_PERMISSION_LEVELS.OWNER;
 
   //updateExisting - This macro will check if a scan journal entry exists and
   update it, set this to false if you want it to create a new scan journal
@@ -61,10 +61,10 @@ command: >-
   const updateExisting = true;
 
   //actorPermissionLevel - This sets the permission level for the parent actor
-  of a token. This must be an integer between -1 and 3 where -1 is "No change",
-  0 is "None", 1 is "Limited", 2 is "Observer", and 3 is "Owner"
+  of a token (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED,
+  OBSERVER, or OWNER). If set to `null`, no change is made.
 
-  const actorPermissionLevel = -1;
+  const actorPermissionLevel = null;
 
   //targets - Gets the data for your currently selected target(s) and stores it
   for later use. Do not change.
@@ -254,7 +254,7 @@ command: >-
 
   targets.forEach(async target => {
     let actor = target.actor;
-    if (actorPermissionLevel >= 0) {
+    if (actorPermissionLevel !== null) {
       const actorId = actor.system.parent._id;
       const parentActor = game.actors.get(actorId);
       parentActor.update({ ownership: { default: actorPermissionLevel } });
@@ -409,6 +409,6 @@ _stats:
   systemVersion: 2.1.5
   coreVersion: '11.315'
   createdTime: null
-  modifiedTime: 1720298820356
+  modifiedTime: 1720304546588
   lastModifiedBy: VTqqjv3vCWDxBIi5
 _key: '!macros!z0pdvwE0FitMzwRJ'


### PR DESCRIPTION
Add an optional parameter, `actorPermissionLevel`, to both Scan macros. When set to an integer greater than or equal to 0, it sets the Default Permission Level to `actorPermissionLevel`. Default value of `actorPermissionLevel` is `-1`.