### PR TITLE
Fix tech attack not consuming lock on

### DIFF
--- a/src/module/flows/system.ts
+++ b/src/module/flows/system.ts
@@ -82,7 +82,7 @@ async function printSystemCard(
     // attackData: {
     //   origin: state.actor.id,
     //   targets: state.data.attack_rolls.targeted.map(t => {
-    //     return { id: t.target.id, lockOnConsumed: !!t.usedLockOn };
+    //     return { id: t.target.id, setConditions: !!t.usedLockOn ? { lockon: !t.usedLockOn } : undefined };
     //   }),
     // },
   };

--- a/src/module/flows/tech.ts
+++ b/src/module/flows/tech.ts
@@ -183,7 +183,7 @@ export async function printTechAttackCard(
     attackData: {
       origin: state.actor.id,
       targets: state.data.attack_rolls.targeted.map(t => {
-        return { id: t.target.id, lockOnConsumed: !!t.usedLockOn };
+        return { id: t.target.id, setConditions: !!t.usedLockOn ? { lockon: !t.usedLockOn } : undefined };
       }),
     },
   };


### PR DESCRIPTION
When the tech attack card is made, I think it has the wrong targets returned.