### PR TITLE
Improve accessibility of checkboxes in the attack hud

### DIFF
--- a/src/module/helpers/acc_diff/Form.svelte
+++ b/src/module/helpers/acc_diff/Form.svelte
@@ -284,6 +284,11 @@
     font-size: 0.9em;
     user-select: none;
     align-items: center;
+    cursor: pointer;
+  }
+
+  #accdiff :global(.container:has(input[disabled])) {
+    cursor: unset;
   }
 
   /* Hide the browser's default checkbox */
@@ -309,7 +314,7 @@
   }
 
   #accdiff :global(.container:hover input:not([disabled]) ~ .checkmark) {
-    background-color: #757575;
+    box-shadow: 0px 0px 8px var(--primary-color);
   }
 
   #accdiff :global(.container input:checked ~ .checkmark) {
@@ -322,6 +327,12 @@
     display: none;
   }
   #accdiff :global(.container input:checked ~ .checkmark:after) {
+    content: "×";
+    color: var(--light-text);
+    font-size: 34px;
+    position: absolute;
+    top: -21px;
+    left: 0px;
     display: block;
   }
 

--- a/src/module/helpers/acc_diff/Form.svelte
+++ b/src/module/helpers/acc_diff/Form.svelte
@@ -289,6 +289,7 @@
 
   #accdiff :global(.container:has(input[disabled])) {
     cursor: unset;
+    opacity: 0.5;
   }
 
   /* Hide the browser's default checkbox */
@@ -309,7 +310,6 @@
   }
 
   #accdiff :global(input[disabled] ~ .checkmark) {
-    opacity: 0.5;
     cursor: unset;
   }
 


### PR DESCRIPTION
Currently the checkboxes only indicate ther state by color. This adds a times
sign icon to indicate if a checkbox is checked and improves the hover visual,
using a box shadow rather than a color change. The cursor now changes to
pointer form the labes as well as the checkboxes now.
![image](https://github.com/user-attachments/assets/68efe96e-b4b7-46c5-ba99-675b69692ff7)
![image](https://github.com/user-attachments/assets/b8f85fbe-1659-43a7-9613-747d25a3e64d)
