### PR TITLE
fix: restore (broken) Action Tracker functionality

### DIFF
--- a/public/templates/actor/mech.hbs
+++ b/public/templates/actor/mech.hbs
@@ -89,7 +89,7 @@
           <span class="lancer-header lancer-primary submajor clipped-top">
             {{localize "lancer.mech-sheet.actions.label"}}
           </span>
-          <div class="lancer-action-grid">
+          <div class="lancer-flow-button-grid">
             {{{action-button "Protocol" "system.action_tracker.protocol" "protocol"}}}
             {{{action-button "Movement" "system.action_tracker.move" "move"}}}
             {{{action-button "Full Action" "system.action_tracker.full" "full"}}}

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -8,23 +8,23 @@
   <div style="display:inline-flex;">
     <i id="action-manager-drag" class="mdi mdi-drag"></i>
     <div class="action-bar">
-      <a class="action {{#if actions.protocol}}activation-protocol{{/if}}" data-action="protocol">
+      <a class="action {{#if actions.protocol}}lancer-protocol{{/if}}" data-action="protocol">
         <i class="cci cci-protocol theme--dark white--text"></i>
       </a>
       <hr class="v-divide" role="separator" aria-orientation="undefined" />
-      <a class="action {{#if actions.move}}activation-move{{/if}}" data-action="move">
+      <a class="action {{#if actions.move}}lancer-move{{/if}}" data-action="move">
         <i class="mdi mdi-arrow-right-bold-hexagon-outline theme--dark white--text"></i>
       </a>
-      <a class="action {{#if actions.full}}activation-full{{/if}}" data-action="full">
+      <a class="action {{#if actions.full}}lancer-full{{/if}}" data-action="full">
         <i class="mdi mdi-hexagon-slice-6 theme--dark white--text"></i>
       </a>
-      <a class="action {{#if actions.quick}}activation-quick{{/if}}" data-action="quick">
+      <a class="action {{#if actions.quick}}lancer-quick{{/if}}" data-action="quick">
         <i class="mdi mdi-hexagon-slice-3 theme--dark white--text"></i>
       </a>
-      <a class="action {{#if actions.reaction}}activation-reaction{{/if}}" data-action="reaction">
+      <a class="action {{#if actions.reaction}}lancer-reaction{{/if}}" data-action="reaction">
         <i class="cci cci-reaction theme--dark white--text"></i>
       </a>
-      {{!-- <a class="action {{#if actions.free}}activation-free{{/if}}" data-action="free">
+      {{!-- <a class="action {{#if actions.free}}lancer-free{{/if}}" data-action="free">
         <i class="cci cci-free-action theme--dark white--text"></i>
       </a> --}}
     </div>

--- a/public/templates/window/action_manager.hbs
+++ b/public/templates/window/action_manager.hbs
@@ -3,7 +3,9 @@
   style="width:{{position.width}}px; height:{{position.height}}px; top:{{position.top}}px; left:{{position.left}}px;">
   <div class="action-label">
     <div>{{name}}</div>
+    {{#if clickable}}
     <div style="right: 0px;position: absolute;"><a id="action-manager-reset" class="mdi mdi-restore"></a></div>
+    {{/if}}
   </div>
   <div style="display:inline-flex;">
     <i id="action-manager-drag" class="mdi mdi-drag"></i>

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -2433,8 +2433,9 @@ a.activation-chip > i.mdi {
 .track-message.lancer-action-grid {
   flex-wrap: wrap;
 }
-.track-message .lancer-action-badge {
-  margin: 4px;
+.lancer-action-badge {
+  background-color: var(--light-gray-color);
+  margin: 3px;
   width: fit-content;
 }
 

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -172,6 +172,7 @@ $theme-types: "primary" "secondary" "dark-gray" "light-gray" "tooltip"    // Gen
   "reaction" "protocol" "quick" "full" "move" "free"; // Action types
 @each $theme-type in $theme-types {
   /* Headers, buttons, and chips */
+  a.action.lancer-#{$theme-type},
   .lancer-header.lancer-#{$theme-type},
   .lancer-#{$theme-type} .lancer-header,
   button.lancer-#{$theme-type},

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -25,8 +25,8 @@ export class LancerActionManager extends Application {
 
   target: LancerActor | null = null;
 
-  constructor() {
-    super();
+  constructor(...args: any) {
+    super(...args);
   }
 
   async init() {
@@ -57,13 +57,15 @@ export class LancerActionManager extends Application {
 
   /** @override */
   getData(_options = {}) {
-    return {
+    const data = {
       position: this.position,
       // @ts-expect-error Should be fixed with v10 types
       name: this.target && this.target.name.toLocaleUpperCase(),
       actions: this.getActions(),
       clickable: game.user?.isGM || getActionTrackerOptions().allowPlayers,
     };
+    console.log(this.target);
+    return data;
   }
 
   // DATA BINDING
@@ -112,7 +114,7 @@ export class LancerActionManager extends Application {
       const actor = token.actor as LancerActor;
       // TODO: Remove when action data is properly within MM.
       // @ts-expect-error Should be fixed with v10 types
-      if ((actor.is_mech() || actor.is_npc()) && token.actor.system.action_tracker === undefined) {
+      if ((actor.is_mech() || actor.is_npc()) && token.actor.system.action_tracker !== undefined) {
         this.target = token.actor;
         return this.updateActions(token.actor, _defaultActionData(token.actor));
       }
@@ -161,10 +163,10 @@ export class LancerActionManager extends Application {
 
   private loadUserPos() {
     // @ts-expect-error Should be fixed with v10 types
-    if (!(game.user?.flags["action-manager"] && game.user.flags["action-manager"].pos)) return;
+    if (!game.user.getFlag(game.system.id, "action-manager.pos")) return;
 
     // @ts-expect-error Should be fixed with v10 types
-    const pos = game.user.flags["action-manager"].pos;
+    const pos: any = game.user.getFlag(game.system.id, "action-manager.pos");
     const appPos = this.position;
     return new Promise(resolve => {
       function loop() {

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -134,7 +134,11 @@ export class LancerActionManager extends Application {
     // Enable reset.
     html.find("#action-manager-reset").on("click", e => {
       e.preventDefault();
-      this.resetActions();
+      if (this.canMod()) {
+        this.resetActions();
+      } else {
+        console.log(`${game.user?.name} :: Users currently not allowed to reset actions through action manager.`);
+      }
     });
 
     // Enable action toggles.

--- a/src/module/action/action-manager.ts
+++ b/src/module/action/action-manager.ts
@@ -2,7 +2,7 @@ import type { LancerActor } from "../actor/lancer-actor";
 import type { ActionTrackingData, ActionType } from ".";
 import tippy from "tippy.js";
 import { getActionTrackerOptions } from "../settings";
-import { getActions, modAction, toggleAction, updateActions, _defaultActionData } from "./action-tracker";
+import { getActions, modAction, toggleAction, _defaultActionData } from "./action-tracker";
 
 // TODO: Properly namespace this flag into the system scope
 declare global {
@@ -76,13 +76,6 @@ export class LancerActionManager extends Application {
   private getActions(): ActionTrackingData | null {
     return this.target ? getActions(this.target) : null;
   }
-  /**
-   * Set proxy for ease of migration when we change over to MM data backing.
-   */
-  private async updateActions(actor: LancerActor, actions: ActionTrackingData) {
-    await updateActions(actor, actions);
-    // this.token?.update({ "flags.lancer.actions": actions });
-  }
 
   async reset() {
     await this.close();
@@ -112,11 +105,9 @@ export class LancerActionManager extends Application {
     const token = canvas.tokens?.controlled?.[0];
     if (token && token.inCombat && token.actor) {
       const actor = token.actor as LancerActor;
-      // TODO: Remove when action data is properly within MM.
-      // @ts-expect-error Should be fixed with v10 types
-      if ((actor.is_mech() || actor.is_npc()) && token.actor.system.action_tracker !== undefined) {
+      if (actor.is_mech() || actor.is_npc()) {
         this.target = token.actor;
-        return this.updateActions(token.actor, _defaultActionData(token.actor));
+        return;
       }
     }
     this.target = null;

--- a/src/module/action/action-tracker.ts
+++ b/src/module/action/action-tracker.ts
@@ -29,7 +29,7 @@ export const _endTurnActionData = () => {
  * @returns actions map.
  */
 export function getActions(actor: LancerActor): ActionTrackingData | null {
-  if (actor.is_mech()) {
+  if (actor.is_mech() || actor.is_npc()) {
     return actor.system.action_tracker;
   } else {
     return null;
@@ -39,7 +39,7 @@ export function getActions(actor: LancerActor): ActionTrackingData | null {
  * Set proxy for ease of migration when we change over to MM data backing.
  */
 export async function updateActions(actor: LancerActor, actions: ActionTrackingData) {
-  await actor.update({ "data.action_tracker": actions });
+  await actor.update({ "system.action_tracker": actions });
   // this.token?.update({ "flags.lancer.actions": actions });
 }
 

--- a/src/module/flows/action-track.ts
+++ b/src/module/flows/action-track.ts
@@ -68,9 +68,9 @@ function condensedActionBadgeHTML(actions: ActionTrackingData) {
     }
 
     return `
-        <button class="lancer-${action} lancer-action-badge${active ? ` active` : ""}${
-      false ? ` enabled` : ""
-    }"><i class="${mIcon} i--m"></i></button>`;
+    <button class="lancer-action-badge${active ? ` lancer-${action}` : ""}">
+      <i class="${mIcon} i--m white--text"></i>
+    </button>`;
   }
 
   let buttons = "";

--- a/src/module/helpers/actor.ts
+++ b/src/module/helpers/actor.ts
@@ -222,9 +222,9 @@ export function action_button(
   }
 
   return `
-    <button class="lancer-action-button lancer-button lancer-${action ?? "quick"}${
-    active ? ` active activation-${action}` : ""
-  }${enabled ? ` enabled` : ""}" data-action="${action}" data-val="${action_val}">
+    <button class="lancer-action-button lancer-button enabled${
+      active ? ` active lancer-${action}` : ""
+    }" data-action="${action}" data-val="${action_val}">
       ${title}
     </button>
     `;


### PR DESCRIPTION
This PR fixes functionality related to the Action tracking:
- https://github.com/Eranziel/foundryvtt-lancer/issues/751

I tried to understand the prior behavior and fix what bugs I could find, but am unsure if I got everything.

## Fixes & Improvements

- Action tracker now appears after selecting a Mech token that is engaged in combat
- Action tracker shows colored buttons when actions are available, and gray buttons when unavailable
- Actor's action tracker data now gets updated on turn start and end
- Action tracker's reset button now respects the "Allow players" setting (if disabled they cannot reset)
  - The reset button is no longer rendered if players are not allowed to use it
- Action tracker is displayed when NPC tokens are selected as well
- End of turn message (from "Print Message" Action Tracker setting) differentiates style for spent (colored) vs unspent (gray) actions

## Questions / Discussion

For the `Print Messages` setting in Action Tracker Settings, what is the desired behavior for the end-of-turn action output?
- Should the action badges for unused actions be colored and spent actions grayed out (to draw attention to unused action economy?)
- Or should end-of-turn message provide history about what actions a player took, and color the spent actions / gray out the unused?

Or neither? I see that the code intended to style them differently based on which actions were spent, but that style is gone/broken, so am guessing here.

## Testing

Behavior that I've verified (related to fixes):

- Action tracker appears when a mech or NPC is selected/controlled and is in a (started) combat encounter
  - Actions are colored when available, gray when unavailable
- Actions are refreshed when an actor starts their turn
- Actions are cleared (and reaction refreshed) when an actor's turn ends
- Actions buttons at bottom of `<<MECH//STATS>>` on Sheet update action tracker state
- If action tracker settings has `Allow players` disabled:
  - the reset button is not rendered
  - user cannot use the reset button (even if it was rendered)
- If action tracker settings has `Print Messages` enabled:
  - Message with action info appears in chat at end of turn
  - Action badge style reflects which actions were taken