### PR TITLE
chore: ignore .DS_Store files via .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ package/**
 debug.log
 foundry.js
 .vite-cache
+
+# MacOS filesystem metadata
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to `.gitignore` so contributors on MacOS are not plagued by these metadata files associated with MacOS filesystem.

On MacOS, these files are automatically created to store filesystem/folder metadata.
This avoids cluttered `git status` output and avoids accidentally committing `.DS_Store`