### PR TITLE
fix: exclude deleted pilots from COMPCON pilot cache

### DIFF
--- a/src/module/util/compcon.ts
+++ b/src/module/util/compcon.ts
@@ -25,6 +25,9 @@ export async function populatePilotCache(): Promise<CachedCloudPilot[]> {
     level: "protected",
     // @ts-ignore  Unclear if this still does anything
     cacheControl: "no-cache",
+    // Filter out deleted pilots (tagged with "delete" or "s3-remove-flag"), we want "active"
+  }).then(result => {
+    return result.filter(x => x.key?.endsWith("--active"));
   });
 
   const data = (await Promise.all(res.map(obj => (obj.key ? fetchPilot(obj.key) : null)))).map(


### PR DESCRIPTION
https://github.com/Eranziel/foundryvtt-lancer/pull/706
> Polish: The current implementation has some quirks. For example on my machine/account, every pilot I have ever made and synced is listed even though most have been deleted.

---

This fixes a bug where pilots deleted on COMP/CON would still appear in the list of pilots to sync.

COMP/CON will suffix pilot keys with either `--active`, `--deleted`, or `--s3-remove-flag`. The latter two are for pilots that have been deleted (permanently or staged) via COMP/CON.

Filtering with `--active` ensures we only show pilots that are not flagged for deletion.

## Notes

Approach here is similar to how COMP/CON filters out "permanently deleted" items via

```ts
  return Storage.list('', { level: 'protected' })
    .then(result => {
      return result.filter(x => !x.key.includes('s3-remove-flag'))
    })
    .catch(err => console.error(err))
```
https://github.com/massif-press/compcon/blob/28c8a88772ffa6c1a5932275449e0866d50495fc/src/cloud/item_sync.ts#L27-L29

## Testing

I have a permanently deleted pilot, a (staged for deletion) pilot, and some active ones on COMPCON cloud.

Verified I only see the active ones in the list.