### PR TITLE
Skip structure roll for NPCs with a single structure

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -347,7 +347,9 @@
       "npc_recharge": "NPC Recharge",
       "npc_recharge-desc": "Automatically roll to recharge NPC systems at the start of their turn.",
       "token_size": "Manage Token Sizes",
-      "token_size-desc": "Automatically force tokens sizes to match the associated actor's size stat."
+      "token_size-desc": "Automatically force tokens sizes to match the associated actor's size stat.",
+      "one_struct_npc_roll": "Skip Basic NPC Structure Rolls",
+      "one_struct_npc_roll-desc": "Remove the structure roll prompt when single structure NPCs are destroyed."
     },
     "actionTracker": {
       "menu-name": "Action Tracker",

--- a/public/templates/window/automation-config.hbs
+++ b/public/templates/window/automation-config.hbs
@@ -94,6 +94,17 @@
     <p class="notes">{{ localize "lancer.automation.token_size-desc" }}</p>
   </div>
   <div class="form-group">
+    <label>{{ localize "lancer.automation.one_struct_npc_roll" }}</label>
+    <input
+        type="checkbox"
+        name="one_struct_npc_roll"
+        {{#if one_struct_npc_roll}}checked{{/if}}
+        {{#unless enabled}}disabled{{/unless}}
+        data-dtype="Boolean"
+    />
+    <p class="notes">{{ localize "lancer.automation.one_struct_npc_roll-desc" }}</p>
+  </div>
+  <div class="form-group">
     <button type="submit" name="submit">
       <i class="fas fa-save"></i>
       <span>Save</span>

--- a/src/module/flows/structure.ts
+++ b/src/module/flows/structure.ts
@@ -74,7 +74,7 @@ export async function preStructureRollChecks(
       return false;
     }
     // If it's an NPC with a single structure, no need to roll. (Core Rule Book pp 281)
-    if (actor.system.structure.max === 1 && actor.is_npc) {
+    if (actor.system.structure.max === 1 && actor.is_npc()) {
       await actor.update({
         "system.structure": actor.system.structure.value - 1,
       });

--- a/src/module/flows/structure.ts
+++ b/src/module/flows/structure.ts
@@ -73,6 +73,13 @@ export async function preStructureRollChecks(
       ui.notifications!.info("Token has hp remaining. No need to roll structure.");
       return false;
     }
+    // If it's an NPC with a single structure, no need to roll. (Core Rule Book pp 281)
+    if (actor.system.structure.max === 1) {
+      await actor.update({
+        "system.structure": actor.system.structure.value - 1,
+      });
+      return true;
+    }
     const { openSlidingHud: open } = await import("../apps/slidinghud");
     try {
       await open("struct", { stat: "structure", title: "Structure Damage", lancerActor: actor });

--- a/src/module/flows/structure.ts
+++ b/src/module/flows/structure.ts
@@ -74,7 +74,7 @@ export async function preStructureRollChecks(
       return false;
     }
     // If it's an NPC with a single structure, no need to roll. (Core Rule Book pp 281)
-    if (actor.system.structure.max === 1) {
+    if (actor.system.structure.max === 1 && actor.is_npc) {
       await actor.update({
         "system.structure": actor.system.structure.value - 1,
       });

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -221,6 +221,7 @@ export function getAutomationOptions(useDefault = false): AutomationOptions {
     npc_recharge: true,
     remove_templates: false,
     token_size: true,
+    one_struct_npc_roll: false,
   };
   if (useDefault) return def;
   const settings = (game.settings.get(game.system.id, LANCER.setting_automation) as Record<string, boolean>) ?? {};
@@ -241,6 +242,7 @@ export function getAutomationOptions(useDefault = false): AutomationOptions {
       npc_recharge: false,
       remove_templates: false,
       token_size: false,
+      one_struct_npc_roll: false,
     };
   }
 }
@@ -297,6 +299,11 @@ export interface AutomationOptions {
    * @defaultValue `true`
    */
   token_size: boolean;
+  /**
+   * Skip structure rolls for NPCs with a single structure
+   * @defaultValue `false`
+   */
+  one_struct_npc_roll: boolean;
 }
 
 //


### PR DESCRIPTION
I was asked to update Lancer QoL with this, but I think this is a rule that should probably be in the system.

The rule states:
> NPCs only have 1 Structure and are destroyed when they reach 0 HP. NPCs with additional Structure follow the standard rules for structure damage.

I check before the Structure roll HUD is displayed to just decrement the structure and return true to hit the rest of the flows.