### PR TITLE
Use downandout as the defeated status

### DIFF
--- a/src/module/effects/lancer-active-effect.ts
+++ b/src/module/effects/lancer-active-effect.ts
@@ -228,6 +228,9 @@ export class LancerActiveEffect extends ActiveEffect {
     }
     console.log(`Lancer | ${configStatuses.length} status icons configured`);
     CONFIG.statusEffects = configStatuses;
+    // Use downandout to mark units as defeated
+    // @ts-expect-error v10 types
+    CONFIG.specialStatusEffects.DEFEATED = "downandout";
     // Disable the vision mechanics Foundry applies to certain status names
     // @ts-expect-error v10 types
     CONFIG.specialStatusEffects.INVISIBLE = "ignored";


### PR DESCRIPTION
I thought I set this in the v11 update, but I apparently dropped the
commit.
