### PR TITLE
Restore activations display in combat tracker

### DIFF
--- a/public/templates/combat/combat-tracker.hbs
+++ b/public/templates/combat/combat-tracker.hbs
@@ -91,6 +91,10 @@
                         <i class="fa-solid fa-arrows-to-eye"></i>
                     </a>
                     {{/unless}}
+                    <span class="activations" data-tooltip="lancer.Actor.FIELDS.activations.label">
+                        <i class="cci cci-activate"></i>
+                        <span>{{this.activations}}</span>
+                    </span>
                     <div class="token-effects">
                         {{#each this.effects}}
                         <img class="token-effect" src="{{this}}"/>

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -1,6 +1,9 @@
 /* TODO: Maybe multiple stylesheets is a good idea? Check out ITCSS and segment them by their layer */
 /* TODO: Webcomponents. Tags, cards, compact stat */
 
+@use "styles/settings/lancer-initiative-config";
+@use "styles/combat/lancer-combat-tracker";
+
 /* Item/document types, useful for shorthand */
 $item-types: core_bonus environment faction frame manufacturer npc_class npc_template npc_feature weapon_mod mech_system
   mech_weapon organization pilot_armor pilot_gear pilot_weapon reserve sitrep skill status tag talent quirk;
@@ -33,14 +36,6 @@ $document-types: join($item-types, $actor-types);
   --ssc-color: #d1920a;
   --horus-color: #00a256;
   --ha-color: #6e4373;
-
-  /* Lancer initiative vars */
-  --lancer-initiative-icon-size: 1rem;
-  --lancer-initiative-player-color: #000000;
-  --lancer-initiative-friendly-color: #000000;
-  --lancer-initiative-neutral-color: #000000;
-  --lancer-initiative-enemy-color: #000000;
-  --lancer-initiative-done-color: #000000;
 
   /* Gear and type color vars */
   --system-color: #58b434;
@@ -136,9 +131,6 @@ $document-types: join($item-types, $actor-types);
     0 100%
   );
 }
-
-@import "styles/settings/lancer-initiative-config";
-@import "styles/combat/lancer-combat-tracker";
 
 code {
   padding: 0px 5px !important;

--- a/src/styles/combat/lancer-combat-tracker.scss
+++ b/src/styles/combat/lancer-combat-tracker.scss
@@ -1,76 +1,65 @@
-li.combatant {
-  border-radius: 5px;
-  &.player {
-    border-left: 3px solid var(--lancer-initiative-player-color);
-    border-right: 3px solid var(--lancer-initiative-player-color);
+:root {
+  --lancer-initiative-icon-size: 1rem;
+  --lancer-initiative-done-color: #000000;
+}
+
+@mixin combatant($disposition) {
+  &.#{$disposition} {
+    border-left: 3px solid var(--lancer-initiative-#{$disposition}-color);
+    border-right: 3px solid var(--lancer-initiative-#{$disposition}-color);
     &.active::after {
-      border-color: var(--lancer-initiative-player-color);
+      border-color: var(--lancer-initiative-#{$disposition}-color);
+    }
+    .token-initiative a {
+      color: var(--lancer-initiative-#{$disposition}-color);
     }
   }
-  &.friendly {
-    border-left: 3px solid var(--lancer-initiative-friendly-color);
-    border-right: 3px solid var(--lancer-initiative-friendly-color);
-    &.active::after {
-      border-color: var(--lancer-initiative-friendly-color);
-    }
-  }
-  &.neutral {
-    border-left: 3px solid var(--lancer-initiative-neutral-color);
-    border-right: 3px solid var(--lancer-initiative-neutral-color);
-    &.active::after {
-      border-color: var(--lancer-initiative-neutral-color);
-    }
-  }
-  &.enemy {
-    border-left: 3px solid var(--lancer-initiative-enemy-color);
-    border-right: 3px solid var(--lancer-initiative-enemy-color);
-    &.active::after {
-      border-color: var(--lancer-initiative-enemy-color);
-    }
-  }
-  &.secret {
-    border-left: 3px solid var(--lancer-initiative-secret-color);
-    border-right: 3px solid var(--lancer-initiative-secret-color);
-    &.active::after {
-      border-color: var(--lancer-initiative-secret-color);
-    }
+  @at-root :root {
+    --lancer-intitiative-#{$disposition}-color: #000000;
   }
 }
 
-[data-tab="combat"] #combat-tracker {
-  .combatant .token-initiative {
-    padding-left: 0.5em;
-    margin-right: 0.25rem;
-    align-items: center;
-    display: flex;
-    position: relative;
-    flex: 0 0 auto;
-  }
-  .combatant .token-initiative i,
-  .combatant .token-initiative a {
-    font-size: var(--lancer-initiative-icon-size);
-  }
-  .combatant.active .token-initiative a.done {
-    color: var(--lancer-initiative-done-color);
-  }
-  .combatant.player .token-initiative a {
-    color: var(--lancer-initiative-player-color);
-  }
-  .combatant.friendly .token-initiative a {
-    color: var(--lancer-initiative-friendly-color);
-  }
-  .combatant.neutral .token-initiative a {
-    color: var(--lancer-initiative-neutral-color);
-  }
-  .combatant.enemy .token-initiative a {
-    color: var(--lancer-initiative-enemy-color);
-  }
-  .combatant.secret .token-initiative a {
-    color: var(--lancer-initiative-secret-color);
-  }
-  li.combatant.turn-done {
-    color: inherit;
-    text-decoration: inherit;
+[data-tab="combat"] {
+  li.combatant {
+    border-radius: 5px;
+    @each $disposition in player friendly neutral enemy {
+      @include combatant($disposition);
+    }
+    .token-initiative {
+      padding-left: 0.5em;
+      margin-right: 0.25rem;
+      align-items: center;
+      display: flex;
+      position: relative;
+      flex: 0 0 auto;
+      a {
+        font-size: var(--lancer-initiative-icon-size);
+        &.done {
+          color: var(--lancer-initiative-done-color);
+        }
+      }
+    }
+    span.activations {
+      flex: 0 0 20px;
+      width: 20px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      i {
+        color: var(--color-text-dark-5);
+        font-size: 20px;
+        position: relative;
+        left: 50%;
+      }
+      span {
+        flex: 0 0 20px;
+        text-align: center;
+        font-size: 14px;
+        position: relative;
+        left: -50%;
+        opacity: 0.8;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
The small icon showing the number of activations in the combat tracker
got dropped when updating the tracker to v12. This adds it back in.
