### PR TITLE
Fix "Scan (Journal)" macros to make it work in foundry v12

### DIFF
--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -49,10 +49,10 @@ command: >-
   const startingNumber = 1;
 
   //permissionLevel - This sets the default permission level of the scan entry
-  (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED, OBSERVER, or
+  (from CONST.DOCUMENT_OWNERSHIP_LEVELS, use NONE, LIMITED, OBSERVER, or
   OWNER).
 
-  const permissionLevel = CONST.DOCUMENT_PERMISSION_LEVELS.OWNER;
+  const permissionLevel = CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
 
   //updateExisting - This macro will check if a scan journal entry exists and
   update it, set this to false if you want it to create a new scan journal
@@ -132,7 +132,8 @@ command: >-
           sc_desc = `Trigger: ${i.system.trigger}<br>${sc_desc}`;
         }
       }
-      let sc_entry = `<details><summary>${sc_name}</summary><p>${sc_desc}</p></details>`;
+      if (!sc_desc.startsWith("<p>") && !sc_desc.startsWith("<P>")) sc_desc = `<p>${sc_desc}</p>`;
+      let sc_entry = `<details><summary>${sc_name}</summary>${sc_desc}</details>`;
       sc_list += sc_entry;
     });
     return sc_list;
@@ -364,33 +365,38 @@ command: >-
     //This checks and updates the scan entry for the target(s) if a single scan entry exists in the specified folder for the target(s) along with the updateExisting flag.
     //If either are false then this creates a new scan entry.
 
-    let scanObj = {};
-
-    scanObj.folder = journalFolder.id;
-
     let scanEntry;
 
-    let matchingJournalEntries = journalFolder.contents.filter(e => e.name.match(actor.name));
+    let matchingJournalEntries = journalFolder.contents.filter(e => e.name.includes(actor.name));
 
     if (matchingJournalEntries.length == 1 && updateExisting === true) {
       console.log("Updating an existing scan");
-      scanObj.name = matchingJournalEntries[0].name;
-      scanObj._id = matchingJournalEntries[0]._id;
-      scanObj.text = {
-        content: scanContent,
-      };
-      scanEntry = game.journal.getName(scanObj.name);
-      let scanPage = scanEntry.pages.getName(scanObj.name);
-      await scanPage.update(scanObj);
+      const scanName = matchingJournalEntries[0].name;
+      scanEntry = game.journal.getName(scanName);
+      let scanPage = scanEntry.pages.getName(scanName);
+      await scanPage.update({
+          _id: matchingJournalEntries[0]._id,
+          text: {
+              content: scanContent,
+          },
+      });
     } else {
       console.log("Creating a new scan");
       let scanCount = zeroPad(
         journalFolder.contents.filter(e => e.name.startsWith(nameTemplate)).length + startingNumber,
         numberLength
       );
-      scanObj.name = nameTemplate + scanCount + ` - ` + actor.name;
-      scanObj.content = scanContent;
-      scanEntry = await JournalEntry.create(scanObj);
+      const scanName = nameTemplate + scanCount + ` - ` + actor.name;
+      let scanPage = new JournalEntryPage({
+          name: scanName,
+          type: "text",
+          text: { content: scanContent},
+      });
+      scanEntry = await JournalEntry.create({
+          folder: journalFolder.id,
+          name: scanName,
+      });
+      scanEntry.createEmbeddedDocuments("JournalEntryPage", [scanPage]);
     }
 
     scanEntry.update({ permission: { default: permissionLevel } });

--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -49,8 +49,7 @@ command: >-
   const startingNumber = 1;
 
   //permissionLevel - This sets the default permission level of the scan entry
-  (from CONST.DOCUMENT_OWNERSHIP_LEVELS, use NONE, LIMITED, OBSERVER, or
-  OWNER).
+  (from CONST.DOCUMENT_OWNERSHIP_LEVELS, use NONE, LIMITED, OBSERVER, or OWNER).
 
   const permissionLevel = CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER;
 
@@ -375,10 +374,10 @@ command: >-
       scanEntry = game.journal.getName(scanName);
       let scanPage = scanEntry.pages.getName(scanName);
       await scanPage.update({
-          _id: matchingJournalEntries[0]._id,
-          text: {
-              content: scanContent,
-          },
+        _id: matchingJournalEntries[0]._id,
+        text: {
+          content: scanContent,
+        },
       });
     } else {
       console.log("Creating a new scan");
@@ -388,13 +387,13 @@ command: >-
       );
       const scanName = nameTemplate + scanCount + ` - ` + actor.name;
       let scanPage = new JournalEntryPage({
-          name: scanName,
-          type: "text",
-          text: { content: scanContent},
+        name: scanName,
+        type: "text",
+        text: { content: scanContent },
       });
       scanEntry = await JournalEntry.create({
-          folder: journalFolder.id,
-          name: scanName,
+        folder: journalFolder.id,
+        name: scanName,
       });
       scanEntry.createEmbeddedDocuments("JournalEntryPage", [scanPage]);
     }
@@ -413,8 +412,10 @@ ownership:
 _stats:
   systemId: lancer
   systemVersion: 2.1.5
-  coreVersion: '11.315'
+  coreVersion: '12.331'
   createdTime: null
-  modifiedTime: 1720304546588
-  lastModifiedBy: VTqqjv3vCWDxBIi5
+  modifiedTime: 1740552081051
+  lastModifiedBy: Ol18KgPyh9PbrR3Z
+  compendiumSource: null
+  duplicateSource: null
 _key: '!macros!z0pdvwE0FitMzwRJ'


### PR DESCRIPTION
It seems like Foundry v12 finally dropped the older pre-v10 compatibility for creating the first journal page directly.

This PR:
- When creating a new scan entry, create the journal document, then add the contents as a page
- Do some cleanup of the "update an existing scan" vs "create a new scan entry" branches. _I think there's more cleanup could be done here, but I don't have a good workflow setup for producing the YAML formatting mode used by the macro from base JS text._
- Improve the handling of paragraph text in item entries. Base items benefit from the paragraph tags, but the formatting gets wonky if the GM has modified an NPC's item descriptions (eg, to add flavor text).