### PR TITLE
Read C/C export as string instead of binary

### DIFF
--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -153,12 +153,12 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
     console.log(`${lp} Selected file changed`, jsonFile);
     const fr = new FileReader();
     fr.addEventListener("load", ev => {
-      this._onPilotJsonParsed(ev.target?.result as string, this.actor);
+      this._onPilotJsonParsed(ev.target?.result as string);
     });
     fr.readAsText(jsonFile);
   }
 
-  async _onPilotJsonParsed(fileData: string | null, actor: LancerActor) {
+  async _onPilotJsonParsed(fileData: string | null) {
     if (!fileData) return;
     const pilotData = JSON.parse(fileData) as PackedPilotData;
     console.log(`${lp} Pilot Data of selected JSON:`, pilotData);

--- a/src/module/actor/pilot-sheet.ts
+++ b/src/module/actor/pilot-sheet.ts
@@ -115,7 +115,7 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
       }
 
       // JSON Import
-      html.find("#pilot-json-import").on("change", ev => this._onPilotJsonUpload(ev));
+      html.find<HTMLInputElement>("input#pilot-json-import").on("change", ev => this._onPilotJsonUpload(ev));
 
       // editing rawID clears vaultID
       // (other way happens automatically because we prioritise vaultID in commit)
@@ -146,18 +146,16 @@ export class LancerPilotSheet extends LancerActorSheet<EntryType.PILOT> {
     }
   }
 
-  _onPilotJsonUpload(ev: JQuery.ChangeEvent<HTMLElement, undefined, HTMLElement, HTMLElement>) {
-    let files = (ev.target as HTMLInputElement).files;
-    let jsonFile: File | null = null;
-    if (files) jsonFile = files[0];
+  _onPilotJsonUpload(ev: JQuery.ChangeEvent<HTMLInputElement, undefined, HTMLInputElement, HTMLInputElement>) {
+    const jsonFile = ev.target.files?.[0];
     if (!jsonFile) return;
 
     console.log(`${lp} Selected file changed`, jsonFile);
     const fr = new FileReader();
-    fr.readAsBinaryString(jsonFile);
-    fr.addEventListener("load", (ev: ProgressEvent) => {
-      this._onPilotJsonParsed((ev.target as FileReader).result as string, this.actor);
+    fr.addEventListener("load", ev => {
+      this._onPilotJsonParsed(ev.target?.result as string, this.actor);
     });
+    fr.readAsText(jsonFile);
   }
 
   async _onPilotJsonParsed(fileData: string | null, actor: LancerActor) {


### PR DESCRIPTION
Reading as binary caused problems with non-ASCII files, such as files
using Cyrillic characters.  By reading the file as text, the FileReader
is allowed to interpret the file as the appropriate encoding instead of
bruteforce reading it as ASCII.

Fixes: #818
