### PR TITLE
Account for House Guard 1 in Spotter detection

### DIFF
--- a/src/module/apps/acc_diff/spotter.ts
+++ b/src/module/apps/acc_diff/spotter.ts
@@ -31,18 +31,7 @@ function adjacentSpotter(actor: LancerActor): boolean {
       const house_guard: boolean =
         o.t.actor.system.pilot?.value?.itemTypes.talent.some(t => t.system.lid === "t_house_guard") ?? false;
       const range = (house_guard ? 2 : 1) + 0.1;
-      if (canvas.grid!.isGridless) {
-        const distance =
-          canvas.grid!.measurePath([o.t.center, token.center], {}).distance -
-          (o.t.document.width! + token.document.width!) / 2 +
-          1;
-        return distance < range;
-      } else {
-        const distances = o.t
-          .getOccupiedSpaces()
-          .flatMap(s => token.getOccupiedSpaces().map(t => canvas.grid!.measurePath([s, t], {}).distance));
-        return distances.some(distance => distance < range);
-      }
+      return o.t.document.computeRange(token.document) <= range;
     },
   }) as any;
   return spotters.size >= 1;

--- a/src/module/apps/acc_diff/spotter.ts
+++ b/src/module/apps/acc_diff/spotter.ts
@@ -4,6 +4,7 @@ import type { AccDiffHudData, AccDiffHudTarget } from "./index";
 import type { LancerActor, LancerMECH, LancerPILOT } from "../../actor/lancer-actor";
 import type { LancerToken } from "../../token";
 import { LancerTALENT } from "../../item/lancer-item";
+import type BaseGrid from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/grid/base.mjs";
 
 // this is an example of a case implemented without defining a full class
 function adjacentSpotter(actor: LancerActor): boolean {
@@ -12,25 +13,39 @@ function adjacentSpotter(actor: LancerActor): boolean {
     return false;
   }
 
-  // computation shamelessly stolen from sensor-sight
-
   let token: LancerToken = actor.getActiveTokens()[0];
 
-  const spaces = token.getOccupiedSpaces();
-  function adjacent(token: LancerToken) {
-    const otherSpaces = token.getOccupiedSpaces();
-    const rays = spaces.flatMap(s => otherSpaces.map(t => ({ ray: new Ray(s, t) })));
-    const min_d = Math.min(...canvas.grid!.grid!.measureDistances(rays, { gridSpaces: true }));
-    return min_d < 1.1;
-  }
+  // Rough bounding box with allowance for hg1
+  const aabb = new PIXI.Rectangle(
+    token.bounds.x - 2 * canvas.grid!.sizeX,
+    token.bounds.y - 2 * canvas.grid!.sizeY,
+    token.bounds.right + 4 * canvas.grid!.sizeX,
+    token.bounds.bottom + 4 * canvas.grid!.sizeY
+  );
 
-  // TODO: TYPECHECK: all of this seems to work
-  let adjacentPilots = (canvas!.tokens!.objects!.children as LancerToken[])
-    .filter((t: LancerToken) => t.actor?.is_mech() && adjacent(t) && t.id != token.id)
-    .map((t: LancerToken) => (t.actor! as LancerMECH).system.pilot?.value)
-    .filter(x => x) as LancerPILOT[];
-
-  return adjacentPilots.some(p => p?.itemTypes.talent.find(t => (t as LancerTALENT).system.lid == "t_spotter"));
+  const spotters: Set<LancerToken> = canvas.tokens!.quadtree!.getObjects(aabb, {
+    // @ts-expect-error Quadtree not set specific enough in types
+    collisionTest: (o: QuadtreeObject<LancerToken>) => {
+      if (!o.t.actor?.is_mech() || o.t === token) return false;
+      if (!o.t.actor.system.pilot?.value?.itemTypes.talent.some(t => t.system.lid === "t_spotter")) return false;
+      const house_guard: boolean =
+        o.t.actor.system.pilot?.value?.itemTypes.talent.some(t => t.system.lid === "t_house_guard") ?? false;
+      const range = (house_guard ? 2 : 1) + 0.1;
+      if (canvas.grid!.isGridless) {
+        const distance =
+          canvas.grid!.measurePath([o.t.center, token.center], {}).distance -
+          (o.t.document.width! + token.document.width!) / 2 +
+          1;
+        return distance < range;
+      } else {
+        const distances = o.t
+          .getOccupiedSpaces()
+          .flatMap(s => token.getOccupiedSpaces().map(t => canvas.grid!.measurePath([s, t], {}).distance));
+        return distances.some(distance => distance < range);
+      }
+    },
+  }) as any;
+  return spotters.size >= 1;
 }
 
 function spotter(): AccDiffHudPluginData {

--- a/src/module/apps/slidinghud/user-targets.ts
+++ b/src/module/apps/slidinghud/user-targets.ts
@@ -1,4 +1,5 @@
 import { readable } from "svelte/store";
+import type { LancerToken } from "../../token";
 
 export const userTargets = readable([] as Token[], update => {
   function updateData() {
@@ -13,5 +14,8 @@ export const userTargets = readable([] as Token[], update => {
   Hooks.on("createActiveEffect", updateData);
   Hooks.on("deleteActiveEffect", updateData);
   // updateToken triggers on things like token movement (spotter) and probably a lot of other things
-  Hooks.on("updateToken", updateData);
+  Hooks.on<Hooks.UpdateDocument<typeof TokenDocument>>("updateToken", token => {
+    // If there's an anmiation, update when it finishes, otherwise just update
+    CanvasAnimation.getAnimation(token.object?.animationName!)?.promise.then(() => updateData()) ?? updateData();
+  });
 });

--- a/src/module/token.ts
+++ b/src/module/token.ts
@@ -99,6 +99,28 @@ export class LancerTokenDocument extends TokenDocument {
       }
     }
   }
+
+  /**
+   * Calculate the range between this and other, accounting for occupied spaces
+   * and size
+   * @param other   Target to check against
+   * @returns The range in grid units.
+   */
+  computeRange(other: LancerTokenDocument): number {
+    const grid = this.parent?.grid ?? canvas.grid;
+    if (!grid || !canvas.ready) throw new Error("Canvas not ready");
+    if (!this.object || !other.object) throw new Error("Tokens not drawn to canvas");
+
+    if (grid.isGridless) {
+      const c2c = grid.measurePath([this.object.center, other.object.center], {}).distance;
+      return c2c - (this.width! + other.width!) / 2 + 1;
+    } else {
+      const distances = this.object
+        .getOccupiedSpaces()
+        .flatMap(s => other.object!.getOccupiedSpaces().map(t => grid.measurePath([s, t], {}).spaces));
+      return Math.min(...distances);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Rewrites the spotter detection to use the canvas quadtree to filter for
tokens to avoid running checks on irrelevant tokens.  When determining
adjacency range, increase the distance to 2 spaces if the spotter also
has the House Guard talent.

Fixes: #793 