### PR TITLE
Fixed typo in Scan__Journal__z0pdvwE0FitMzwRJ.yml

### DIFF
--- a/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
+++ b/src/packs/core_macros/Scan__Journal__z0pdvwE0FitMzwRJ.yml
@@ -60,7 +60,7 @@ command: >-
   const updateExisting = true;
 
   //actorPermissionLevel - This sets the permission level for the parent actor
-  of a token (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED,
+  of a token (from CONST.DOCUMENT_OWNERSHIP_LEVELS, use NONE, LIMITED,
   OBSERVER, or OWNER). If set to `null`, no change is made.
 
   const actorPermissionLevel = null;


### PR DESCRIPTION
Fixed typo in comment on line63 from:

of a token (from CONST.DOCUMENT_PERMISSION_LEVELS, use NONE, LIMITED,

to

of a token (from CONST.DOCUMENT_OWNERSHIP_LEVELS, use NONE, LIMITED,