### PR TITLE
V3 import update - bug fixes

### DIFF
--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -17,7 +17,7 @@ import {
   type LancerRESERVE,
   type LancerWEAPON_MOD,
 } from "../item/lancer-item";
-import type { PowerData } from "../models/bits/power";
+import { type PowerData, unpackPower } from "../models/bits/power";
 import type { SourceData } from "../source-template";
 import { get_pack_id, insinuate } from "../util/doc";
 import { fromLid } from "../helpers/from-lid";
@@ -81,7 +81,6 @@ async function updatePilot(
       default_value: 0,
     };
   };
-
   await pilot.update({
     name: data.name,
     img: replaceDefaultResource(pilot.img, portrait),
@@ -568,21 +567,61 @@ export async function importCCv3(
     // Bonds
     if (data.bond?.bondId) {
       const item = data.bond;
-      const bond = (await getOrCreateActorItemByLid(
+      let bond = (await getOrCreateActorItemByLid(
         item.bondId,
         pilot,
         pilotItemPool,
         _missingItems
       )) as LancerBOND | null;
       if (!bond) {
-        await pilot.createEmbeddedDocuments("Item", [
-          {
-            ...unpackBond(item.data),
-            type: EntryType.BOND,
-            name: item.data.name,
-          },
-        ]);
+        bond = (
+          await pilot.createEmbeddedDocuments("Item", [
+            {
+              ...unpackBond(item.data),
+              type: EntryType.BOND,
+              name: item.data.name,
+            },
+          ])
+        )[0] as LancerBOND;
       }
+
+      // Update powers
+      // If it does not have an origin, it is from the originating bond ID
+      // while Veteran and Master powers always come with their origin.
+      const unlockedPowersSet = new Set(
+        item.bondPowers.filter(p => !p.origin || p.origin === item.bondId).map(p => p.name)
+      );
+      const unlockedPowers = bond.system.powers.map((p: PowerData) => ({
+        ...p,
+        unlocked: unlockedPowersSet.has(p.name!),
+      }));
+      const findPowerInCompendiums = async (name: string) => {
+        const compendiumPacks = game.packs.get(get_pack_id(EntryType.BOND));
+        const compendiumBonds: LancerItem[] | null =
+          ((await compendiumPacks?.getDocuments({ type: EntryType.BOND })) as unknown as LancerItem[]) ?? null;
+        if (!compendiumBonds) return undefined;
+        for (const bond of compendiumBonds) {
+          if (!bond.is_bond()) continue;
+          const found = bond.system.powers.find(p => p.name === name);
+          if (found) return found;
+        }
+      };
+
+      // Unpack other bonds' powers if necessary and unlock appropriate powers
+      const foreignPowers = [];
+      for (const power of data.bond.bondPowers) {
+        // Check compendiums first... note that this is much less efficient than just simply building the power
+        const foundPower = (await findPowerInCompendiums(power.name)) ?? unpackPower(power);
+        foreignPowers.push({
+          ...foundPower,
+          unlocked: true, // If a foreign power is being added it can be safely assumed it is unlocked
+        });
+      }
+      await bond.update({
+        system: {
+          powers: [...foreignPowers],
+        },
+      });
     }
 
     // Licenses

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -367,8 +367,7 @@ export async function importCCv3(pilot: LancerPILOT, importedData: PackedPilotWr
     const pilotItemPool = [...pilot.items.contents];
     let selectedLoadout = 0;
 
-    // Get the object by LIDs first if able as a natural guard against incomplete data
-    // and then overwrite with values in the importing data
+    // Get the object by LIDs first or create from scratch using CC data
     const gears: string[] = [];
     const armors: string[] = [];
     const weapons: string[] = [];

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -341,12 +341,19 @@ export async function importCCv3(
   clearFirst = true
 ) {
   console.log(`${lp} Importing v3 Pilot`, pilot, importedData);
-  if (!pilot.is_pilot()) console.error(`${lp} Actor was not a pilot type`, pilot);
-  if (!importedData) console.error(`${lp} Imported data is missing`, importedData);
+  if (!pilot.is_pilot()) {
+    console.error(`${lp} Actor was not a pilot type`, pilot);
+    return;
+  }
+  if (!importedData) {
+    console.error(`${lp} Imported data is missing`, importedData);
+    return;
+  }
   // CCv3 JSON exports have a wrapper that is missing in sharecode/cloud fetching
   const data: PackedPilotData = "EXPORT_TYPE" in importedData ? importedData.data : importedData;
   if (!data) {
     console.error(`${lp} Tried using CCv3 importer on CCv2 data`, importedData);
+    return;
   }
 
   if (clearFirst) {

--- a/src/module/actor/import.ts
+++ b/src/module/actor/import.ts
@@ -321,7 +321,10 @@ export async function importCC(
   importedData: PackedPilotData | PackedPilotWrapper,
   clearFirst = true
 ) {
-  if ("EXPORT_TYPE" in importedData) {
+  // CCv3 JSON exports have a wrapper that is missing in sharecode/cloud fetching
+  // `originId` is some arbitrary V3 exclusive data; it can be anything else.
+  // `EXPORT_TYPE` is exclusive to V3 and only in JSON exports.
+  if ("originId" in importedData || "EXPORT_TYPE" in importedData) {
     await importCCv3(pilot, importedData, clearFirst);
   } else {
     await importCCv2(pilot, importedData, clearFirst);
@@ -332,11 +335,16 @@ export async function importCC(
  * Imports packed pilot data from CCv3.
  * Minimum import version: CCv3.0.4
  */
-export async function importCCv3(pilot: LancerPILOT, importedData: PackedPilotWrapper, clearFirst = true) {
+export async function importCCv3(
+  pilot: LancerPILOT,
+  importedData: PackedPilotWrapper | PackedPilotData,
+  clearFirst = true
+) {
   console.log(`${lp} Importing v3 Pilot`, pilot, importedData);
   if (!pilot.is_pilot()) console.error(`${lp} Actor was not a pilot type`, pilot);
   if (!importedData) console.error(`${lp} Imported data is missing`, importedData);
-  const data = importedData.data;
+  // CCv3 JSON exports have a wrapper that is missing in sharecode/cloud fetching
+  const data: PackedPilotData = "EXPORT_TYPE" in importedData ? importedData.data : importedData;
   if (!data) {
     console.error(`${lp} Tried using CCv3 importer on CCv2 data`, importedData);
   }

--- a/src/module/enums.ts
+++ b/src/module/enums.ts
@@ -368,22 +368,20 @@ export enum RangeType {
 export type RangeTypeChecklist = { [key in RangeType]: boolean };
 
 export enum DamageType {
-  Kinetic = "kinetic",
-  Energy = "energy",
-  Explosive = "explosive",
-  Heat = "heat",
-  Burn = "burn",
-  Variable = "variable", // Only in CCv2(?)
-  Aoe = "aoe",
-  All = "all",
+  Kinetic = "Kinetic",
+  Energy = "Energy",
+  Explosive = "Explosive",
+  Heat = "Heat",
+  Burn = "Burn",
+  Variable = "Variable",
 }
 
 export type DamageTypeChecklist = { [key in DamageType]: boolean };
 
 export enum AttackType {
-  Melee = "melee",
-  Ranged = "ranged",
-  Tech = "tech",
+  Melee = "Melee",
+  Ranged = "Ranged",
+  Tech = "Tech",
 }
 
 export type AttackTypeChecklist = { [key in AttackType]: boolean };

--- a/src/module/util/unpacking/packed-types.ts
+++ b/src/module/util/unpacking/packed-types.ts
@@ -19,6 +19,9 @@ import {
   PilotItemType,
 } from "../../enums";
 
+export type PackedDamageType = Lowercase<DamageType> | "aoe" | "all"; // CCv3 drops the 'variable' type and adds 'aoe' and 'all'
+export type PackedAttackType = Lowercase<AttackType>;
+
 export interface PackedBrewData {
   LcpId: string;
   LcpName: string;
@@ -98,7 +101,7 @@ export interface PackedActiveEffectData {
   remove_special?: string[];
   add_other?: PackedOtherEffectData;
   save?: HASE | PackedSaveData;
-  attack?: AttackType;
+  attack?: PackedAttackType;
   pilot?: boolean;
   mech?: boolean;
 }
@@ -116,9 +119,9 @@ export interface PackedStatusEffectData {
 // New in CCv3:
 // https://github.com/massif-press/lancer-data/wiki/active-effects#add_resist
 export interface PackedResistanceData {
-  immunity?: DamageType | StatusConditionType;
-  resistance?: DamageType;
-  vulnerability?: DamageType;
+  immunity?: PackedDamageType | StatusConditionType;
+  resistance?: PackedDamageType;
+  vulnerability?: PackedDamageType;
   target?: TargetDisposition;
 }
 
@@ -148,7 +151,7 @@ export interface PackedSaveData {
 }
 
 export interface PackedDamageData {
-  type?: DamageType; // Required in CCv3
+  type?: PackedDamageType; // Required in CCv3
   val?: string | number; // Required in CCv3
   override?: boolean; // If player can set the damage of this, I guess????
 
@@ -173,7 +176,7 @@ export interface PackedRangeData {
 export interface PackedBonusData {
   id: string;
   val: string | number;
-  damage_types?: DamageType[];
+  damage_types?: PackedDamageType[];
   range_types?: RangeType[];
   weapon_types?: WeaponType[];
   weapon_sizes?: WeaponSize[];

--- a/src/module/util/unpacking/packed-types.ts
+++ b/src/module/util/unpacking/packed-types.ts
@@ -984,6 +984,7 @@ export interface PackedBondPowerData {
   veteran: boolean | undefined;
   master: boolean | undefined;
   prerequisite: string | undefined;
+  origin: string | undefined;
 }
 
 export interface PackedClockBurdenData {


### PR DESCRIPTION
Changes are described in commit messages

Addresses 3 main bugs:
- #939 
- Reverts enum values used by the system (mainly DamageType). This also sidesteps the issue addressed in #940 until V3 LCPs are supported
- When using the cloud-fetched pilots, data was prepared in an unexpected way compared to JSON, leading to usage of the V2 importer on V3 pilots