### PR TITLE
Add Plain Font Setting For Accessibility

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -39,7 +39,9 @@
     "LancerNPCFeatureSheet": "Lancer System NPC Feature Sheet",
     "Actor": {
       "FIELDS": {
-        "activations": { "label": "Activations" }
+        "activations": {
+          "label": "Activations"
+        }
       }
     },
     "placeholder": {
@@ -247,6 +249,10 @@
     "floatingDamageNumbers": {
       "name": "Floating Damage Numbers",
       "hint": "Enable floating damage numbers for changes to stats, including applying damage rolls. This setting is separate for each client."
+    },
+    "simpleFonts": {
+      "name": "Use Simple/Plain Fonts",
+      "hint": "Replace sci-fi style fonts (e.g. Orbitron headers) with Helvetica. This setting is separate for each client."
     },
     "uiTheme": {
       "name": "UI Theme",

--- a/src/lancer.scss
+++ b/src/lancer.scss
@@ -105,4 +105,14 @@
   /* Elements Layer */
 
   /* ---------- */
+
+  /* Simple fonts override */
+  body.lancer-simple-fonts {
+    --header-font-family: Helvetica, Arial, sans-serif;
+
+    /* Pause overlay is intentionally excluded from the simple fonts setting */
+    #pause.lancer-pause figcaption {
+      font-family: Orbitron, Helvetica, Arial, sans-serif;
+    }
+  }
 }

--- a/src/lancer.ts
+++ b/src/lancer.ts
@@ -33,7 +33,7 @@ import { richTextEdit } from "./module/apps/text-editor";
 import { LCPManager, addLCPManagerButton } from "./module/apps/lcp-manager/lcp-manager";
 import { preloadTemplates } from "./module/preload-templates";
 import { registerSettings } from "./module/settings";
-import { applyTheme } from "./module/themes";
+import { applyTheme, applySimpleFonts } from "./module/themes";
 import * as migrations from "./module/world_migration";
 
 // Import sliding HUD (used for accuracy/difficulty windows)
@@ -203,6 +203,8 @@ Hooks.once("init", () => {
   registerSettings();
   // Apply theme colors
   applyTheme(game.settings.get(game.system.id, LANCER.setting_ui_theme) as "gms" | "msmc" | "horus");
+  // Apply simple fonts if enabled
+  applySimpleFonts(game.settings.get(game.system.id, LANCER.setting_simple_fonts) as boolean);
 
   // Register flow steps
   const { flows, flowSteps } = registerFlows();

--- a/src/module/config.ts
+++ b/src/module/config.ts
@@ -58,6 +58,7 @@ export const LANCER = {
   setting_dsn_setup: "dsnSetup",
   setting_square_grid_diagonals: "squareGridDiagonals",
   setting_tag_config: "tagConfig",
+  setting_simple_fonts: "simpleFonts",
   // setting_120: "warningFor120", // Old setting, currently unused.
   // setting_beta_warning: "warningForBeta", // Old setting, currently unused.
 } as const;

--- a/src/module/integrations/lancer-combat-tracker-dock.scss
+++ b/src/module/integrations/lancer-combat-tracker-dock.scss
@@ -73,7 +73,7 @@
 
         p,
         ul {
-          font-family: Consolas;
+          font-family: var(--monospace-font-family);
           font-size: var(--font-size-10);
           color: var(--light-text);
           margin: 0.2em;

--- a/src/module/settings.ts
+++ b/src/module/settings.ts
@@ -5,7 +5,7 @@ import type { LancerCombat, LancerCombatant } from "./combat/lancer-combat";
 import { setAppearance } from "./combat/lancer-combat-tracker";
 import { LANCER } from "./config";
 import { LancerActiveEffect } from "./effects/lancer-active-effect";
-import { applyTheme } from "./themes";
+import { applyTheme, applySimpleFonts } from "./themes";
 import fields = foundry.data.fields;
 
 export const registerSettings = function () {
@@ -52,6 +52,16 @@ export const registerSettings = function () {
     config: true,
     type: Boolean,
     default: false,
+  });
+
+  game.settings.register(game.system.id, LANCER.setting_simple_fonts, {
+    name: "lancer.simpleFonts.name",
+    hint: "lancer.simpleFonts.hint",
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (v: boolean) => applySimpleFonts(v),
   });
 
   game.settings.register(game.system.id, LANCER.setting_ui_theme, {

--- a/src/module/themes.ts
+++ b/src/module/themes.ts
@@ -9,6 +9,12 @@ const themeClassMap = {
   gal: "theme-galsim",
 };
 
+export function applySimpleFonts(enabled: boolean) {
+  const body = document.querySelector("body");
+  if (!body) return;
+  body.classList.toggle("lancer-simple-fonts", enabled);
+}
+
 export function applyTheme(theme: "gms" | "gmsDark" | "msmc" | "horus" | "ha" | "ssc" | "ipsn" | "gal") {
   const body = document.querySelector("body");
   if (!body) return;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -111,7 +111,7 @@
     letter-spacing: 0.1em !important;
     line-height: 1.2rem;
     text-transform: uppercase;
-    font-family: Roboto, sans-serif !important;
+    font-family: var(--main-font-family) !important;
   }
 
   /** Fixes CSS priority on flexrows within cards */


### PR DESCRIPTION
This feature adds a "Simple/Plain Font" accessibility toggle in the system settings which allows a user to replace all sci-fi fonts with Helvetica. The pause menu is excluded because it looks rather awkward without the stylish text.

Made following some mentions of individuals with dyslexia struggling to read the new fonts.
<img width="1185" height="724" alt="image" src="https://github.com/user-attachments/assets/e3142081-f324-4f84-85cb-68447a663164" />
<img width="513" height="36" alt="image" src="https://github.com/user-attachments/assets/9a0475d6-5cdc-46f1-aa31-efa8d9a93b90" />
